### PR TITLE
update related, add gulp-micromatch

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -515,7 +515,7 @@ As of {%= date() %}:
 Please be sure to run the benchmarks before/after any code changes to judge the impact before you do a PR. thanks!
 
 ## Related 
-{%= related(['braces', 'extglob', 'expand-brackets', 'fill-range', 'expand-range', 'parse-glob', 'is-glob']) %}
+{%= related(['braces', 'extglob', 'expand-brackets', 'fill-range', 'expand-range', 'gulp-micromatch', 'parse-glob', 'is-glob'], {words: 9}) %}
 
 ## Author
 

--- a/.verb.md
+++ b/.verb.md
@@ -497,7 +497,7 @@ Whenever possible parsing behavior for patterns is based on globbing specificati
 Run the [benchmarks](./benchmark):
 
 ```bash
-npm run benchmark
+node benchmark
 ```
 
 As of {%= date() %}:

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Whenever possible parsing behavior for patterns is based on globbing specificati
 Run the [benchmarks](./benchmark):
 
 ```bash
-npm run benchmark
+node benchmark
 ```
 
 As of May 05, 2015:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch. Just use `micromatch.isMatch()` instead of `minimatch()`, or use `micromatch()` instead of `multimatch()`.
 
-## Install with [npm](npmjs.org)
+Install with [npm](https://www.npmjs.com/)
 
 ```bash
 npm i micromatch --save
@@ -16,28 +16,28 @@ npm i micromatch --save
 - [Usage](#usage)
 - [Switch from minimatch](#switch-from-minimatch)
 - [Methods](#methods)
-  * [.isMatch](#-ismatch)
-  * [.contains](#-contains)
-  * [.matcher](#-matcher)
-  * [.filter](#-filter)
-  * [.any](#-any)
-  * [.expand](#-expand)
-  * [.makeRe](#-makere)
+  * [.isMatch](#ismatch)
+  * [.contains](#contains)
+  * [.matcher](#matcher)
+  * [.filter](#filter)
+  * [.any](#any)
+  * [.expand](#expand)
+  * [.makeRe](#makere)
 - [Options](#options)
-  * [options.unixify](#options-unixify)
-  * [options.dot](#options-dot)
-  * [options.unescape](#options-unescape)
-  * [options.nodupes](#options-nodupes)
-  * [options.matchBase](#options-matchbase)
-  * [options.braces](#options-braces)
-  * [options.nobraces](#options-nobraces)
-  * [options.brackets](#options-brackets)
-  * [options.nobrackets](#options-nobrackets)
-  * [options.extglob](#options-extglob)
-  * [options.noextglob](#options-noextglob)
-  * [options.nocase](#options-nocase)
-  * [options.nonull](#options-nonull)
-  * [options.cache](#options-cache)
+  * [options.unixify](#optionsunixify)
+  * [options.dot](#optionsdot)
+  * [options.unescape](#optionsunescape)
+  * [options.nodupes](#optionsnodupes)
+  * [options.matchBase](#optionsmatchbase)
+  * [options.braces](#optionsbraces)
+  * [options.nobraces](#optionsnobraces)
+  * [options.brackets](#optionsbrackets)
+  * [options.nobrackets](#optionsnobrackets)
+  * [options.extglob](#optionsextglob)
+  * [options.noextglob](#optionsnoextglob)
+  * [options.nocase](#optionsnocase)
+  * [options.nonull](#optionsnonull)
+  * [options.cache](#optionscache)
 - [Other features](#other-features)
   * [Extended globbing](#extended-globbing)
     + [extglobs](#extglobs)
@@ -68,12 +68,12 @@ Micromatch is [10-55x faster](#benchmarks) than [minimatch], resulting from a co
 
 **Mainstream glob features:**
 
- + [Brace Expansion][braces] (`foo/bar-{1..5}.md`, `one/{two,three}/four.md`)
++ [Brace Expansion][braces] (`foo/bar-{1..5}.md`, `one/{two,three}/four.md`)
  + Typical glob patterns, like `**/*`, `a/b/*.js`, or `['foo/*.js', '!bar.js']`
 
 **Extended globbing features:**
 
- + Logical `OR` (`foo/bar/(abc|xyz).js`)
++ Logical `OR` (`foo/bar/(abc|xyz).js`)
  + Regex character classes (`foo/bar/baz-[1-5].js`)
  + POSIX [bracket expressions][expand-brackets] (`**/[[:alpha:][:digit:]]/`)
  + [extglobs][extglob] (`**/+(x|y)`, `!(a|b)`, etc)
@@ -144,7 +144,6 @@ mm.isMatch('foo.js', '*.js');
 
 This implementation difference is necessary since the main `micromatch()` method supports matching on multiple globs, with behavior similar to [multimatch].
 
-
 ## Methods
 
 ```js
@@ -158,7 +157,6 @@ mm.isMatch(filepath, globPattern);
 ```
 
 Returns true if a file path matches the given glob pattern.
-
 
 **Example**
 
@@ -245,7 +243,6 @@ arr.filter(fn);
 
 _(Internally this function generates the matching function by using the [matcher] method. You can use the [matcher] method directly to create your own filter function)_
 
-
 ### .any
 
 Returns true if a file path matches any of the given patterns.
@@ -260,7 +257,6 @@ mm.any(filepath, patterns, options);
 - patterns `{String|Array}`: One or more glob patterns
 - options: `{Object}`: options to pass to the `.matcher()` method.
 
-
 **Example**
 
 ```js
@@ -273,7 +269,6 @@ mm.any('abc', 'a*');
 mm.any('abc', ['z*']);
 //=> false
 ```
-
 
 ### .expand
 
@@ -326,7 +321,6 @@ Type: `{Boolean}`
 
 Default: `undefined` on non-windows, `true` on windows.
 
-
 ### options.dot
 
 Match dotfiles. Same behavior as [minimatch].
@@ -334,7 +328,6 @@ Match dotfiles. Same behavior as [minimatch].
 Type: `{Boolean}`
 
 Default: `false`
-
 
 ### options.unescape
 
@@ -397,7 +390,6 @@ Type: `{Boolean}`
 
 Default: `undefined`
 
-
 ### options.nobraces
 
 Don't expand braces in glob patterns. Same behavior as [minimatch] `nobrace`.
@@ -405,7 +397,6 @@ Don't expand braces in glob patterns. Same behavior as [minimatch] `nobrace`.
 Type: `{Boolean}`
 
 Default: `undefined`
-
 
 ### options.brackets
 
@@ -415,7 +406,6 @@ Type: `{Boolean}`
 
 Default: `undefined`
 
-
 ### options.nobrackets
 
 Don't expand POSIX bracket expressions. 
@@ -423,7 +413,6 @@ Don't expand POSIX bracket expressions.
 Type: `{Boolean}`
 
 Default: `undefined`
-
 
 ### options.extglob
 
@@ -433,7 +422,6 @@ Type: `{Boolean}`
 
 Default: `undefined`
 
-
 ### options.noextglob
 
 Don't expand extended globs.
@@ -441,7 +429,6 @@ Don't expand extended globs.
 Type: `{Boolean}`
 
 Default: `undefined`
-
 
 ### options.nocase
 
@@ -451,7 +438,6 @@ Type: `{Boolean}`
 
 Default: `false`
 
-
 ### options.nonull
 
 If `true`, when no matches are found the actual (array-ified) glob pattern is returned instead of an empty array. Same behavior as [minimatch].
@@ -460,7 +446,6 @@ Type: `{Boolean}`
 
 Default: `false`
 
-
 ### options.cache
 
 Cache the platform (e.g. `win32`) to prevent this from being looked up for every filepath.
@@ -468,7 +453,6 @@ Cache the platform (e.g. `win32`) to prevent this from being looked up for every
 Type: `{Boolean}`
 
 Default: `true`
-
 
 ## Other features
 
@@ -500,7 +484,6 @@ Here are some powerful features unique to brace expansion (versus character clas
 
  - range expansion: `a{1..3}b/*.js` expands to: `['a1b/*.js', 'a2b/*.js', 'a3b/*.js']`
  - nesting: `a{c,{d,e}}b/*.js` expands to: `['acb/*.js', 'adb/*.js', 'aeb/*.js']`
-
 
 Learn about [brace expansion][braces], or visit [braces][braces] to ask questions and create an issue related to brace-expansion, or to see the full range of features and options related to brace expansion.
 
@@ -540,7 +523,6 @@ mm.isMatch('a1', '[[:alpha:][:digit:]]');
 
 Whenever possible parsing behavior for patterns is based on globbing specifications in Bash 4.3. Patterns that aren't described by Bash follow wildmatch spec (used by git).
 
-
 ## Benchmarks
 
 Run the [benchmarks](./benchmark):
@@ -549,64 +531,78 @@ Run the [benchmarks](./benchmark):
 npm run benchmark
 ```
 
-As of April 18, 2015:
+As of May 05, 2015:
 
 ```bash
-#1: basename-braces
-  micromatch x 28,631 ops/sec ±0.87% (95 runs sampled)
+# 1: basename-braces
+
+micromatch x 28,631 ops/sec ±0.87% (95 runs sampled)
   minimatch x 3,342 ops/sec ±0.66% (99 runs sampled)
 
-#2: basename
-  micromatch x 29,048 ops/sec ±0.57% (94 runs sampled)
+# 2: basename
+
+micromatch x 29,048 ops/sec ±0.57% (94 runs sampled)
   minimatch x 4,066 ops/sec ±0.65% (98 runs sampled)
 
-#3: braces-no-glob
-  micromatch x 392,536 ops/sec ±0.78% (94 runs sampled)
+# 3: braces-no-glob
+
+micromatch x 392,536 ops/sec ±0.78% (94 runs sampled)
   minimatch x 27,715 ops/sec ±0.55% (92 runs sampled)
 
-#4: braces
-  micromatch x 78,032 ops/sec ±0.49% (97 runs sampled)
+# 4: braces
+
+micromatch x 78,032 ops/sec ±0.49% (97 runs sampled)
   minimatch x 2,733 ops/sec ±0.57% (98 runs sampled)
 
-#5: immediate
-  micromatch x 22,808 ops/sec ±0.68% (95 runs sampled)
+# 5: immediate
+
+micromatch x 22,808 ops/sec ±0.68% (95 runs sampled)
   minimatch x 3,997 ops/sec ±0.53% (96 runs sampled)
 
-#6: large
-  micromatch x 795 ops/sec ±0.73% (95 runs sampled)
+# 6: large
+
+micromatch x 795 ops/sec ±0.73% (95 runs sampled)
   minimatch x 15.78 ops/sec ±1.30% (43 runs sampled)
 
-#7: long
-  micromatch x 6,471 ops/sec ±0.58% (94 runs sampled)
+# 7: long
+
+micromatch x 6,471 ops/sec ±0.58% (94 runs sampled)
   minimatch x 549 ops/sec ±0.67% (93 runs sampled)
 
-#8: mid
-  micromatch x 57,209 ops/sec ±0.56% (100 runs sampled)
+# 8: mid
+
+micromatch x 57,209 ops/sec ±0.56% (100 runs sampled)
   minimatch x 1,569 ops/sec ±0.63% (97 runs sampled)
 
-#9: multi-patterns
-  micromatch x 24,622 ops/sec ±0.67% (94 runs sampled)
+# 9: multi-patterns
+
+micromatch x 24,622 ops/sec ±0.67% (94 runs sampled)
   minimatch x 2,148 ops/sec ±0.95% (94 runs sampled)
 
-#10: no-glob
-  micromatch x 552,083 ops/sec ±0.62% (94 runs sampled)
+# 10: no-glob
+
+micromatch x 552,083 ops/sec ±0.62% (94 runs sampled)
   minimatch x 54,492 ops/sec ±0.57% (98 runs sampled)
 
-#11: range
-  micromatch x 307,461 ops/sec ±0.69% (95 runs sampled)
+# 11: range
+
+micromatch x 307,461 ops/sec ±0.69% (95 runs sampled)
   minimatch x 13,807 ops/sec ±0.65% (96 runs sampled)
 
-#12: shallow
-  micromatch x 238,743 ops/sec ±0.65% (94 runs sampled)
+# 12: shallow
+
+micromatch x 238,743 ops/sec ±0.65% (94 runs sampled)
   minimatch x 18,767 ops/sec ±0.56% (98 runs sampled)
 
-#13: short
-  micromatch x 590,975 ops/sec ±0.56% (96 runs sampled)
+# 13: short
+
+micromatch x 590,975 ops/sec ±0.56% (96 runs sampled)
   minimatch x 56,849 ops/sec ±0.77% (94 runs sampled)
 
 ```
 
 ## Run tests
+
 Install dev dependencies:
 
 ```bash
@@ -614,33 +610,37 @@ npm i -d && npm test
 ```
 
 ## Contributing
+
 Pull requests and stars are always welcome. For bugs and feature requests, [please create an issue](https://github.com/jonschlinkert/micromatch/issues)
 
 Please be sure to run the benchmarks before/after any code changes to judge the impact before you do a PR. thanks!
 
 ## Related 
- * [braces](https://github.com/jonschlinkert/braces): Fastest brace expansion for node.js, with the most complete support for the Bash 4.3 braces specification.
- * [extglob](https://github.com/jonschlinkert/extglob): Convert extended globs to regex-compatible strings. Add (almost) the expressive power of regular expressions to glob patterns.
- * [expand-brackets](https://github.com/jonschlinkert/expand-brackets): Expand POSIX bracket expressions (character classes) in glob patterns.
- * [fill-range](https://github.com/jonschlinkert/fill-range): Fill in a range of numbers or letters, optionally passing an increment or multiplier to use.
- * [expand-range](https://github.com/jonschlinkert/expand-range): Fast, bash-like range expansion. Expand a range of numbers or letters, uppercase or lowercase. See the benchmarks. Used by micromatch.
- * [parse-glob](https://github.com/jonschlinkert/parse-glob): Parse a glob pattern into an object of tokens.
- * [is-glob](https://github.com/jonschlinkert/is-glob): Returns `true` if the given string looks like a glob pattern.
+
+* [braces](https://github.com/jonschlinkert/braces): Fastest brace expansion for node.js, with the most complete… [more](https://github.com/jonschlinkert/braces)
+* [extglob](https://github.com/jonschlinkert/extglob): Convert extended globs to regex-compatible strings. Add (almost) the… [more](https://github.com/jonschlinkert/extglob)
+* [expand-brackets](https://github.com/jonschlinkert/expand-brackets): Expand POSIX bracket expressions (character classes) in glob patterns.
+* [expand-range](https://github.com/jonschlinkert/expand-range): Fast, bash-like range expansion. Expand a range of numbers… [more](https://github.com/jonschlinkert/expand-range)
+* [fill-range](https://github.com/jonschlinkert/fill-range): Fill in a range of numbers or letters, optionally… [more](https://github.com/jonschlinkert/fill-range)
+* [gulp-micromatch](https://github.com/tunnckoCore/gulp-micromatch#readme): micromatch as gulp plugin. Filtering vinyl files with glob… [more](https://github.com/tunnckoCore/gulp-micromatch#readme)
+* [is-glob](https://github.com/jonschlinkert/is-glob): Returns `true` if the given string looks like a… [more](https://github.com/jonschlinkert/is-glob)
+* [parse-glob](https://github.com/jonschlinkert/parse-glob): Parse a glob pattern into an object of tokens.
 
 ## Author
 
 **Jon Schlinkert**
- 
+
 + [github/jonschlinkert](https://github.com/jonschlinkert)
 + [twitter/jonschlinkert](http://twitter.com/jonschlinkert) 
 
 ## License
-Copyright (c) 2014-2015 Jon Schlinkert  
-Released under the MIT license
+
+Copyright (c) 2014-2015 Jon Schlinkert
+Released under the MIT license.
 
 ***
 
-_This file was generated by [verb-cli](https://github.com/assemble/verb-cli) on April 18, 2015._
+_This file was generated by [verb-cli](https://github.com/assemble/verb-cli) on May 05, 2015._
 
 [braces]: https://github.com/jonschlinkert/braces
 [expand-brackets]: https://github.com/jonschlinkert/expand-brackets
@@ -655,3 +655,9 @@ _This file was generated by [verb-cli](https://github.com/assemble/verb-cli) on 
 [extended]: http://mywiki.wooledge.org/BashGuide/Patterns#Extended_Globs
 
 <!-- deps:mocha browserify -->
+
+<!-- reflinks generated by verb-reflinks plugin -->
+
+[assemble]: http://assemble.io
+[template]: https://github.com/jonschlinkert/template
+[verb]: https://github.com/assemble/verb


### PR DESCRIPTION
and truncate the list using `{words: 9}` option for helper-related

- update benchmark command
- fix TOC anchor links, from https://github.com/jonschlinkert/micromatch/issues/27 (just automatically)