### PR TITLE
update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   "bugs": {
     "url": "https://github.com/jonschlinkert/micromatch/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/jonschlinkert/micromatch/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "files": [
     "index.js",
     "lib/"


### PR DESCRIPTION
license objects and a "licenses" property containing an array of license objects are now deprecated from npm@v2.10+

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

i dont envy you @jonschlinkert , lol