### PR TITLE
2.3.7

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -19,14 +19,14 @@
 + Built-in support for multiple glob patterns, like `['foo/*.js', '!bar.js']`
 + [Brace Expansion][braces] (`foo/bar-{1..5}.md`, `one/{two,three}/four.md`)
 + Typical glob patterns, like `**/*`, `a/b/*.js`, or `['foo/*.js', '!bar.js']`
-+ Methods like `.isMatch()`, `.contains()` and `.any()` 
++ Methods like `.isMatch()`, `.contains()` and `.any()`
 
 **Extended globbing features:**
 
 + Logical `OR` (`foo/bar/(abc|xyz).js`)
 + Regex character classes (`foo/bar/baz-[1-5].js`)
 + POSIX [bracket expressions][expand-brackets] (`**/[[:alpha:][:digit:]]/`)
-+ [extglobs][extglob] (`**/+(x|y)`, `!(a|b)`, etc). 
++ [extglobs][extglob] (`**/+(x|y)`, `!(a|b)`, etc).
 
 You can combine these to create whatever matching patterns you need.
 
@@ -99,7 +99,7 @@ mm(['a.md', 'b.js', 'c.txt', 'd.json'], ['*.md', '*.txt']);
 
 Behavior is designed to be what users would expect, based on conventions that are already well-established.
 
-- [minimatch][] behavior is used when the pattern is a string, so patterns are **inclusive by default**. 
+- [minimatch][] behavior is used when the pattern is a string, so patterns are **inclusive by default**.
 - [multimatch][] behavior is used when an array of patterns is passed, so patterns are **exclusive by default**.
 
 ```js
@@ -178,11 +178,11 @@ var files = [];
 
 ### .filter
 
-Returns a function that can be passed to `Array#filter()`. 
+Returns a function that can be passed to `Array#filter()`.
 
 **Params**
 
-- `patterns` **{String|Array}**: 
+- `patterns` **{String|Array}**:
 
 **Examples**
 
@@ -367,7 +367,7 @@ See [braces][] for more information about extended brace expansion.
 
 ### options.nobrackets
 
-Don't expand POSIX bracket expressions. 
+Don't expand POSIX bracket expressions.
 
 Type: `{Boolean}`
 
@@ -489,6 +489,17 @@ See [expand-brackets][] for more information about extended bracket expressions.
 
 Whenever possible parsing behavior for patterns is based on globbing specifications in Bash 4.3. Patterns that aren't described by Bash follow wildmatch spec (used by git).
 
+## Lazy caching
+
+By default micromatch uses [lazy-cache][] to defer loading dependencies until they're used. To disable lazy caching use the `.unlazy` method to get a `micromatch` function with all dependencies loaded immediately.
+
+**Example**
+
+```js
+var mm = require('micromatch').unlazy();
+mm.isMatch('foo.js', '*.js');
+//=> 'true'
+```
 
 ## Benchmarks
 
@@ -524,5 +535,5 @@ Lines      : 100% (429/429)
 
 Please be sure to run the benchmarks before/after any code changes to judge the impact before you do a PR. thanks!
 
-## Related 
+## Related
 {%= related(verb.related.list) %}

--- a/index.js
+++ b/index.js
@@ -11,418 +11,439 @@ var expand = require('./lib/expand');
 var utils = require('./lib/utils');
 
 /**
- * The main function. Pass an array of filepaths,
- * and a string or array of glob patterns
- *
- * @param  {Array|String} `files`
- * @param  {Array|String} `patterns`
- * @param  {Object} `opts`
- * @return {Array} Array of matches
- */
-
-function micromatch(files, patterns, opts) {
-  if (!files || !patterns) return [];
-  opts = opts || {};
-
-  if (typeof opts.cache === 'undefined') {
-    opts.cache = true;
-  }
-
-  if (!Array.isArray(patterns)) {
-    return match(files, patterns, opts);
-  }
-
-  var len = patterns.length, i = 0;
-  var omit = [], keep = [];
-
-  while (len--) {
-    var glob = patterns[i++];
-    if (typeof glob === 'string' && glob.charCodeAt(0) === 33 /* ! */) {
-      omit.push.apply(omit, match(files, glob.slice(1), opts));
-    } else {
-      keep.push.apply(keep, match(files, glob, opts));
-    }
-  }
-  return utils.diff(keep, omit);
-}
-
-/**
- * Pass an array of files and a glob pattern as a string.
- *
- * This function is called by the main `micromatch` function
- * If you only need to pass a single pattern you might get
- * very minor speed improvements using this function.
- *
- * @param  {Array} `files`
- * @param  {Array} `pattern`
- * @param  {Object} `options`
- * @return {Array}
- */
-
-function match(files, pattern, opts) {
-  if (utils.typeOf(files) !== 'string' && !Array.isArray(files)) {
-    throw new Error(msg('match', 'files', 'a string or array'));
-  }
-
-  files = utils.arrayify(files);
-  opts = opts || {};
-
-  var negate = opts.negate || false;
-  var orig = pattern;
-
-  if (typeof pattern === 'string') {
-    negate = pattern.charAt(0) === '!';
-    if (negate) {
-      pattern = pattern.slice(1);
-    }
-
-    // we need to remove the character regardless,
-    // so the above logic is still needed
-    if (opts.nonegate === true) {
-      negate = false;
-    }
-  }
-
-  var _isMatch = matcher(pattern, opts);
-  var len = files.length, i = 0;
-  var res = [];
-
-  while (i < len) {
-    var file = files[i++];
-    var fp = utils.unixify(file, opts);
-
-    if (!_isMatch(fp)) { continue; }
-    res.push(fp);
-  }
-
-  if (res.length === 0) {
-    if (opts.failglob === true) {
-      throw new Error('micromatch.match() found no matches for: "' + orig + '".');
-    }
-
-    if (opts.nonull || opts.nullglob) {
-      res.push(utils.unescapeGlob(orig));
-    }
-  }
-
-  // if `negate` was defined, diff negated files
-  if (negate) { res = utils.diff(files, res); }
-
-  // if `ignore` was defined, diff ignored filed
-  if (opts.ignore && opts.ignore.length) {
-    pattern = opts.ignore;
-    opts = utils.omit(opts, ['ignore']);
-    res = utils.diff(res, micromatch(res, pattern, opts));
-  }
-
-  if (opts.nodupes) {
-    return utils.unique(res);
-  }
-  return res;
-}
-
-/**
- * Returns a function that takes a glob pattern or array of glob patterns
- * to be used with `Array#filter()`. (Internally this function generates
- * the matching function using the [matcher] method).
- *
- * ```js
- * var fn = mm.filter('[a-c]');
- * ['a', 'b', 'c', 'd', 'e'].filter(fn);
- * //=> ['a', 'b', 'c']
- * ```
- *
- * @param  {String|Array} `patterns` Can be a glob or array of globs.
- * @param  {Options} `opts` Options to pass to the [matcher] method.
- * @return {Function} Filter function to be passed to `Array#filter()`.
- */
-
-function filter(patterns, opts) {
-  if (!Array.isArray(patterns) && typeof patterns !== 'string') {
-    throw new TypeError(msg('filter', 'patterns', 'a string or array'));
-  }
-
-  patterns = utils.arrayify(patterns);
-  var len = patterns.length, i = 0;
-  var patternMatchers = Array(len);
-  while (i < len) {
-    patternMatchers[i] = matcher(patterns[i++], opts);
-  }
-
-  return function(fp) {
-    if (fp == null) return [];
-    var len = patternMatchers.length, i = 0;
-    var res = true;
-
-    fp = utils.unixify(fp, opts);
-    while (i < len) {
-      var fn = patternMatchers[i++];
-      if (!fn(fp)) {
-        res = false;
-        break;
-      }
-    }
-    return res;
-  };
-}
-
-/**
- * Returns true if the filepath contains the given
- * pattern. Can also return a function for matching.
- *
- * ```js
- * isMatch('foo.md', '*.md', {});
- * //=> true
- *
- * isMatch('*.md', {})('foo.md')
- * //=> true
- * ```
- *
- * @param  {String} `fp`
- * @param  {String} `pattern`
- * @param  {Object} `opts`
- * @return {Boolean}
- */
-
-function isMatch(fp, pattern, opts) {
-  if (typeof fp !== 'string') {
-    throw new TypeError(msg('isMatch', 'filepath', 'a string'));
-  }
-
-  fp = utils.unixify(fp, opts);
-  if (utils.typeOf(pattern) === 'object') {
-    return matcher(fp, pattern);
-  }
-  return matcher(pattern, opts)(fp);
-}
-
-/**
- * Returns true if the filepath matches the
- * given pattern.
- */
-
-function contains(fp, pattern, opts) {
-  if (typeof fp !== 'string') {
-    throw new TypeError(msg('contains', 'pattern', 'a string'));
-  }
-
-  opts = opts || {};
-  opts.contains = (pattern !== '');
-  fp = utils.unixify(fp, opts);
-
-  if (opts.contains && !utils.isGlob(pattern)) {
-    return fp.indexOf(pattern) !== -1;
-  }
-  return matcher(pattern, opts)(fp);
-}
-
-/**
- * Returns true if a file path matches any of the
- * given patterns.
- *
- * @param  {String} `fp` The filepath to test.
- * @param  {String|Array} `patterns` Glob patterns to use.
- * @param  {Object} `opts` Options to pass to the `matcher()` function.
- * @return {String}
- */
-
-function any(fp, patterns, opts) {
-  if (!Array.isArray(patterns) && typeof patterns !== 'string') {
-    throw new TypeError(msg('any', 'patterns', 'a string or array'));
-  }
-
-  patterns = utils.arrayify(patterns);
-  var len = patterns.length;
-
-  fp = utils.unixify(fp, opts);
-  while (len--) {
-    var isMatch = matcher(patterns[len], opts);
-    if (isMatch(fp)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Filter the keys of an object with the given `glob` pattern
- * and `options`
- *
- * @param  {Object} `object`
- * @param  {Pattern} `object`
- * @return {Array}
- */
-
-function matchKeys(obj, glob, options) {
-  if (utils.typeOf(obj) !== 'object') {
-    throw new TypeError(msg('matchKeys', 'first argument', 'an object'));
-  }
-
-  var fn = matcher(glob, options);
-  var res = {};
-
-  for (var key in obj) {
-    if (obj.hasOwnProperty(key) && fn(key)) {
-      res[key] = obj[key];
-    }
-  }
-  return res;
-}
-
-/**
- * Return a function for matching based on the
- * given `pattern` and `options`.
- *
- * @param  {String} `pattern`
- * @param  {Object} `options`
- * @return {Function}
- */
-
-function matcher(pattern, opts) {
-  // pattern is a function
-  if (typeof pattern === 'function') {
-    return pattern;
-  }
-  // pattern is a regex
-  if (pattern instanceof RegExp) {
-    return function(fp) {
-      return pattern.test(fp);
-    };
-  }
-
-  if (typeof pattern !== 'string') {
-    throw new TypeError(msg('matcher', 'pattern', 'a string, regex, or function'));
-  }
-
-  // strings, all the way down...
-  pattern = utils.unixify(pattern, opts);
-
-  // pattern is a non-glob string
-  if (!utils.isGlob(pattern)) {
-    return utils.matchPath(pattern, opts);
-  }
-  // pattern is a glob string
-  var re = makeRe(pattern, opts);
-
-  // `matchBase` is defined
-  if (opts && opts.matchBase) {
-    return utils.hasFilename(re, opts);
-  }
-  // `matchBase` is not defined
-  return function(fp) {
-    fp = utils.unixify(fp, opts);
-    return re.test(fp);
-  };
-}
-
-/**
- * Create and cache a regular expression for matching
- * file paths.
- *
- * If the leading character in the `glob` is `!`, a negation
- * regex is returned.
- *
- * @param  {String} `glob`
- * @param  {Object} `options`
- * @return {RegExp}
- */
-
-function toRegex(glob, options) {
-  // clone options to prevent  mutating the original object
-  var opts = Object.create(options || {});
-  var flags = opts.flags || '';
-  if (opts.nocase && flags.indexOf('i') === -1) {
-    flags += 'i';
-  }
-
-  var parsed = expand(glob, opts);
-
-  // pass in tokens to avoid parsing more than once
-  opts.negated = opts.negated || parsed.negated;
-  opts.negate = opts.negated;
-  glob = wrapGlob(parsed.pattern, opts);
-  var re;
-
-  try {
-    re = new RegExp(glob, flags);
-    return re;
-  } catch (err) {
-    err.reason = 'micromatch invalid regex: (' + re + ')';
-    if (opts.strict) throw new SyntaxError(err);
-  }
-
-  // we're only here if a bad pattern was used and the user
-  // passed `options.silent`, so match nothing
-  return /$^/;
-}
-
-/**
- * Create the regex to do the matching. If the leading
- * character in the `glob` is `!` a negation regex is returned.
- *
- * @param {String} `glob`
- * @param {Boolean} `negate`
- */
-
-function wrapGlob(glob, opts) {
-  var prefix = (opts && !opts.contains) ? '^' : '';
-  var after = (opts && !opts.contains) ? '$' : '';
-  glob = ('(?:' + glob + ')' + after);
-  if (opts && opts.negate) {
-    return prefix + ('(?!^' + glob + ').*$');
-  }
-  return prefix + glob;
-}
-
-/**
- * Wrap `toRegex` to memoize the generated regex when
- * the string and options don't change
- */
-
-function makeRe(glob, opts) {
-  if (utils.typeOf(glob) !== 'string') {
-    throw new Error(msg('makeRe', 'glob', 'a string'));
-  }
-  return utils.cache(toRegex, glob, opts);
-}
-
-/**
- * Make error messages consistent. Follows this format:
- *
- * ```js
- * msg(methodName, argNumber, nativeType);
- * // example:
- * msg('matchKeys', 'first', 'an object');
- * ```
- *
- * @param  {String} `method`
- * @param  {String} `num`
- * @param  {String} `type`
- * @return {String}
- */
-
-function msg(method, what, type) {
-  return 'micromatch.' + method + '(): ' + what + ' should be ' + type + '.';
-}
-
-/**
- * Public methods
- */
-
-/* eslint no-multi-spaces: 0 */
-micromatch.any       = any;
-micromatch.braces    = micromatch.braceExpand = utils.braces;
-micromatch.contains  = contains;
-micromatch.expand    = expand;
-micromatch.filter    = filter;
-micromatch.isMatch   = isMatch;
-micromatch.makeRe    = makeRe;
-micromatch.match     = match;
-micromatch.matcher   = matcher;
-micromatch.matchKeys = matchKeys;
-
-/**
  * Expose `micromatch`
  */
 
-module.exports = micromatch;
+module.exports = create(utils, expand);
+
+/**
+ * Expose `unlazy` to allow loading dependencies immediately.
+ *
+ * ```js
+ * var mm = require('micromatch').unlazy();
+ * ```
+ *
+ * @return {Function} micromatch
+ */
+
+module.exports.unlazy = function() {
+  var expand = require('./lib/expand').unlazy();
+  var utils = require('./lib/utils').unlazy();
+  return create(utils, expand);
+};
+
+function create(utils, expand) {
+
+  /**
+   * The main function. Pass an array of filepaths,
+   * and a string or array of glob patterns
+   *
+   * @param  {Array|String} `files`
+   * @param  {Array|String} `patterns`
+   * @param  {Object} `opts`
+   * @return {Array} Array of matches
+   */
+
+  function micromatch(files, patterns, opts) {
+    if (!files || !patterns) return [];
+    opts = opts || {};
+
+    if (typeof opts.cache === 'undefined') {
+      opts.cache = true;
+    }
+
+    if (!Array.isArray(patterns)) {
+      return match(files, patterns, opts);
+    }
+
+    var len = patterns.length, i = 0;
+    var omit = [], keep = [];
+
+    while (len--) {
+      var glob = patterns[i++];
+      if (typeof glob === 'string' && glob.charCodeAt(0) === 33 /* ! */) {
+        omit.push.apply(omit, match(files, glob.slice(1), opts));
+      } else {
+        keep.push.apply(keep, match(files, glob, opts));
+      }
+    }
+    return utils.diff(keep, omit);
+  }
+
+  /**
+   * Pass an array of files and a glob pattern as a string.
+   *
+   * This function is called by the main `micromatch` function
+   * If you only need to pass a single pattern you might get
+   * very minor speed improvements using this function.
+   *
+   * @param  {Array} `files`
+   * @param  {Array} `pattern`
+   * @param  {Object} `options`
+   * @return {Array}
+   */
+
+  function match(files, pattern, opts) {
+    if (utils.typeOf(files) !== 'string' && !Array.isArray(files)) {
+      throw new Error(msg('match', 'files', 'a string or array'));
+    }
+
+    files = utils.arrayify(files);
+    opts = opts || {};
+
+    var negate = opts.negate || false;
+    var orig = pattern;
+
+    if (typeof pattern === 'string') {
+      negate = pattern.charAt(0) === '!';
+      if (negate) {
+        pattern = pattern.slice(1);
+      }
+
+      // we need to remove the character regardless,
+      // so the above logic is still needed
+      if (opts.nonegate === true) {
+        negate = false;
+      }
+    }
+
+    var _isMatch = matcher(pattern, opts);
+    var len = files.length, i = 0;
+    var res = [];
+
+    while (i < len) {
+      var file = files[i++];
+      var fp = utils.unixify(file, opts);
+
+      if (!_isMatch(fp)) { continue; }
+      res.push(fp);
+    }
+
+    if (res.length === 0) {
+      if (opts.failglob === true) {
+        throw new Error('micromatch.match() found no matches for: "' + orig + '".');
+      }
+
+      if (opts.nonull || opts.nullglob) {
+        res.push(utils.unescapeGlob(orig));
+      }
+    }
+
+    // if `negate` was defined, diff negated files
+    if (negate) { res = utils.diff(files, res); }
+
+    // if `ignore` was defined, diff ignored filed
+    if (opts.ignore && opts.ignore.length) {
+      pattern = opts.ignore;
+      opts = utils.omit(opts, ['ignore']);
+      res = utils.diff(res, micromatch(res, pattern, opts));
+    }
+
+    if (opts.nodupes) {
+      return utils.unique(res);
+    }
+    return res;
+  }
+
+  /**
+   * Returns a function that takes a glob pattern or array of glob patterns
+   * to be used with `Array#filter()`. (Internally this function generates
+   * the matching function using the [matcher] method).
+   *
+   * ```js
+   * var fn = mm.filter('[a-c]');
+   * ['a', 'b', 'c', 'd', 'e'].filter(fn);
+   * //=> ['a', 'b', 'c']
+   * ```
+   *
+   * @param  {String|Array} `patterns` Can be a glob or array of globs.
+   * @param  {Options} `opts` Options to pass to the [matcher] method.
+   * @return {Function} Filter function to be passed to `Array#filter()`.
+   */
+
+  function filter(patterns, opts) {
+    if (!Array.isArray(patterns) && typeof patterns !== 'string') {
+      throw new TypeError(msg('filter', 'patterns', 'a string or array'));
+    }
+
+    patterns = utils.arrayify(patterns);
+    var len = patterns.length, i = 0;
+    var patternMatchers = Array(len);
+    while (i < len) {
+      patternMatchers[i] = matcher(patterns[i++], opts);
+    }
+
+    return function(fp) {
+      if (fp == null) return [];
+      var len = patternMatchers.length, i = 0;
+      var res = true;
+
+      fp = utils.unixify(fp, opts);
+      while (i < len) {
+        var fn = patternMatchers[i++];
+        if (!fn(fp)) {
+          res = false;
+          break;
+        }
+      }
+      return res;
+    };
+  }
+
+  /**
+   * Returns true if the filepath contains the given
+   * pattern. Can also return a function for matching.
+   *
+   * ```js
+   * isMatch('foo.md', '*.md', {});
+   * //=> true
+   *
+   * isMatch('*.md', {})('foo.md')
+   * //=> true
+   * ```
+   *
+   * @param  {String} `fp`
+   * @param  {String} `pattern`
+   * @param  {Object} `opts`
+   * @return {Boolean}
+   */
+
+  function isMatch(fp, pattern, opts) {
+    if (typeof fp !== 'string') {
+      throw new TypeError(msg('isMatch', 'filepath', 'a string'));
+    }
+
+    fp = utils.unixify(fp, opts);
+    if (utils.typeOf(pattern) === 'object') {
+      return matcher(fp, pattern);
+    }
+    return matcher(pattern, opts)(fp);
+  }
+
+  /**
+   * Returns true if the filepath matches the
+   * given pattern.
+   */
+
+  function contains(fp, pattern, opts) {
+    if (typeof fp !== 'string') {
+      throw new TypeError(msg('contains', 'pattern', 'a string'));
+    }
+
+    opts = opts || {};
+    opts.contains = (pattern !== '');
+    fp = utils.unixify(fp, opts);
+
+    if (opts.contains && !utils.isGlob(pattern)) {
+      return fp.indexOf(pattern) !== -1;
+    }
+    return matcher(pattern, opts)(fp);
+  }
+
+  /**
+   * Returns true if a file path matches any of the
+   * given patterns.
+   *
+   * @param  {String} `fp` The filepath to test.
+   * @param  {String|Array} `patterns` Glob patterns to use.
+   * @param  {Object} `opts` Options to pass to the `matcher()` function.
+   * @return {String}
+   */
+
+  function any(fp, patterns, opts) {
+    if (!Array.isArray(patterns) && typeof patterns !== 'string') {
+      throw new TypeError(msg('any', 'patterns', 'a string or array'));
+    }
+
+    patterns = utils.arrayify(patterns);
+    var len = patterns.length;
+
+    fp = utils.unixify(fp, opts);
+    while (len--) {
+      var isMatch = matcher(patterns[len], opts);
+      if (isMatch(fp)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Filter the keys of an object with the given `glob` pattern
+   * and `options`
+   *
+   * @param  {Object} `object`
+   * @param  {Pattern} `object`
+   * @return {Array}
+   */
+
+  function matchKeys(obj, glob, options) {
+    if (utils.typeOf(obj) !== 'object') {
+      throw new TypeError(msg('matchKeys', 'first argument', 'an object'));
+    }
+
+    var fn = matcher(glob, options);
+    var res = {};
+
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key) && fn(key)) {
+        res[key] = obj[key];
+      }
+    }
+    return res;
+  }
+
+  /**
+   * Return a function for matching based on the
+   * given `pattern` and `options`.
+   *
+   * @param  {String} `pattern`
+   * @param  {Object} `options`
+   * @return {Function}
+   */
+
+  function matcher(pattern, opts) {
+    // pattern is a function
+    if (typeof pattern === 'function') {
+      return pattern;
+    }
+    // pattern is a regex
+    if (pattern instanceof RegExp) {
+      return function(fp) {
+        return pattern.test(fp);
+      };
+    }
+
+    if (typeof pattern !== 'string') {
+      throw new TypeError(msg('matcher', 'pattern', 'a string, regex, or function'));
+    }
+
+    // strings, all the way down...
+    pattern = utils.unixify(pattern, opts);
+
+    // pattern is a non-glob string
+    if (!utils.isGlob(pattern)) {
+      return utils.matchPath(pattern, opts);
+    }
+    // pattern is a glob string
+    var re = makeRe(pattern, opts);
+
+    // `matchBase` is defined
+    if (opts && opts.matchBase) {
+      return utils.hasFilename(re, opts);
+    }
+    // `matchBase` is not defined
+    return function(fp) {
+      fp = utils.unixify(fp, opts);
+      return re.test(fp);
+    };
+  }
+
+  /**
+   * Create and cache a regular expression for matching
+   * file paths.
+   *
+   * If the leading character in the `glob` is `!`, a negation
+   * regex is returned.
+   *
+   * @param  {String} `glob`
+   * @param  {Object} `options`
+   * @return {RegExp}
+   */
+
+  function toRegex(glob, options) {
+    // clone options to prevent  mutating the original object
+    var opts = Object.create(options || {});
+    var flags = opts.flags || '';
+    if (opts.nocase && flags.indexOf('i') === -1) {
+      flags += 'i';
+    }
+
+    var parsed = expand(glob, opts);
+
+    // pass in tokens to avoid parsing more than once
+    opts.negated = opts.negated || parsed.negated;
+    opts.negate = opts.negated;
+    glob = wrapGlob(parsed.pattern, opts);
+    var re;
+
+    try {
+      re = new RegExp(glob, flags);
+      return re;
+    } catch (err) {
+      err.reason = 'micromatch invalid regex: (' + re + ')';
+      if (opts.strict) throw new SyntaxError(err);
+    }
+
+    // we're only here if a bad pattern was used and the user
+    // passed `options.silent`, so match nothing
+    return /$^/;
+  }
+
+  /**
+   * Create the regex to do the matching. If the leading
+   * character in the `glob` is `!` a negation regex is returned.
+   *
+   * @param {String} `glob`
+   * @param {Boolean} `negate`
+   */
+
+  function wrapGlob(glob, opts) {
+    var prefix = (opts && !opts.contains) ? '^' : '';
+    var after = (opts && !opts.contains) ? '$' : '';
+    glob = ('(?:' + glob + ')' + after);
+    if (opts && opts.negate) {
+      return prefix + ('(?!^' + glob + ').*$');
+    }
+    return prefix + glob;
+  }
+
+  /**
+   * Wrap `toRegex` to memoize the generated regex when
+   * the string and options don't change
+   */
+
+  function makeRe(glob, opts) {
+    if (utils.typeOf(glob) !== 'string') {
+      throw new Error(msg('makeRe', 'glob', 'a string'));
+    }
+    return utils.cache(toRegex, glob, opts);
+  }
+
+  /**
+   * Make error messages consistent. Follows this format:
+   *
+   * ```js
+   * msg(methodName, argNumber, nativeType);
+   * // example:
+   * msg('matchKeys', 'first', 'an object');
+   * ```
+   *
+   * @param  {String} `method`
+   * @param  {String} `num`
+   * @param  {String} `type`
+   * @return {String}
+   */
+
+  function msg(method, what, type) {
+    return 'micromatch.' + method + '(): ' + what + ' should be ' + type + '.';
+  }
+
+  /**
+   * Public methods
+   */
+
+  /* eslint no-multi-spaces: 0 */
+  micromatch.any       = any;
+  micromatch.braces    = micromatch.braceExpand = utils.braces;
+  micromatch.contains  = contains;
+  micromatch.expand    = expand;
+  micromatch.filter    = filter;
+  micromatch.isMatch   = isMatch;
+  micromatch.makeRe    = makeRe;
+  micromatch.match     = match;
+  micromatch.matcher   = matcher;
+  micromatch.matchKeys = matchKeys;
+
+  return micromatch;
+};

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -14,298 +14,318 @@ var Glob = require('./glob');
  * Expose `expand`
  */
 
-module.exports = expand;
+module.exports = create(utils, Glob);
 
 /**
- * Expand a glob pattern to resolve braces and
- * similar patterns before converting to regex.
+ * Expose `unlazy` to allow loading dependencies immediately.
  *
- * @param  {String|Array} `pattern`
- * @param  {Array} `files`
- * @param  {Options} `opts`
- * @return {Array}
+ * ```js
+ * var extend = require('./lib/extend').unlazy();
+ * ```
+ *
+ * @return {Function} extend
  */
 
-function expand(pattern, options) {
-  if (typeof pattern !== 'string') {
-    throw new TypeError('micromatch.expand(): argument should be a string.');
-  }
+module.exports.unlazy = function() {
+  var utils = require('./utils').unlazy();
+  return create(utils, Glob);
+};
 
-  var glob = new Glob(pattern, options || {});
-  var opts = glob.options;
+function create(utils, Glob) {
 
-  if (!utils.isGlob(pattern)) {
-    glob.pattern = glob.pattern.replace(/([\/.])/g, '\\$1');
+  /**
+   * Expand a glob pattern to resolve braces and
+   * similar patterns before converting to regex.
+   *
+   * @param  {String|Array} `pattern`
+   * @param  {Array} `files`
+   * @param  {Options} `opts`
+   * @return {Array}
+   */
+
+  function expand(pattern, options) {
+    if (typeof pattern !== 'string') {
+      throw new TypeError('micromatch.expand(): argument should be a string.');
+    }
+
+    var glob = new Glob(pattern, options || {});
+    var opts = glob.options;
+
+    if (!utils.isGlob(pattern)) {
+      glob.pattern = glob.pattern.replace(/([\/.])/g, '\\$1');
+      return glob;
+    }
+
+    glob.pattern = glob.pattern.replace(/(\+)(?!\()/g, '\\$1');
+    glob.pattern = glob.pattern.split('$').join('\\$');
+
+    if (typeof opts.braces !== 'boolean' && typeof opts.nobraces !== 'boolean') {
+      opts.braces = true;
+    }
+
+    if (glob.pattern === '.*') {
+      return {
+        pattern: '\\.' + star,
+        tokens: tok,
+        options: opts
+      };
+    }
+
+    if (glob.pattern === '*') {
+      return {
+        pattern: oneStar(opts.dot),
+        tokens: tok,
+        options: opts
+      };
+    }
+
+    // parse the glob pattern into tokens
+    glob.parse();
+    var tok = glob.tokens;
+    tok.is.negated = opts.negated;
+
+    // dotfile handling
+    if ((opts.dotfiles === true || tok.is.dotfile) && opts.dot !== false) {
+      opts.dotfiles = true;
+      opts.dot = true;
+    }
+
+    if ((opts.dotdirs === true || tok.is.dotdir) && opts.dot !== false) {
+      opts.dotdirs = true;
+      opts.dot = true;
+    }
+
+    // check for braces with a dotfile pattern
+    if (/[{,]\./.test(glob.pattern)) {
+      opts.makeRe = false;
+      opts.dot = true;
+    }
+
+    if (opts.nonegate !== true) {
+      opts.negated = glob.negated;
+    }
+
+    // if the leading character is a dot or a slash, escape it
+    if (glob.pattern.charAt(0) === '.' && glob.pattern.charAt(1) !== '/') {
+      glob.pattern = '\\' + glob.pattern;
+    }
+
+    /**
+     * Extended globs
+     */
+
+    // expand braces, e.g `{1..5}`
+    glob.track('before braces');
+    if (tok.is.braces) {
+      glob.braces();
+    }
+    glob.track('after braces');
+
+    // expand extglobs, e.g `foo/!(a|b)`
+    glob.track('before extglob');
+    if (tok.is.extglob) {
+      glob.extglob();
+    }
+    glob.track('after extglob');
+
+    // expand brackets, e.g `[[:alpha:]]`
+    glob.track('before brackets');
+    if (tok.is.brackets) {
+      glob.brackets();
+    }
+    glob.track('after brackets');
+
+    // special patterns
+    glob._replace('[!', '[^');
+    glob._replace('(?', '(%~');
+    glob._replace(/\[\]/, '\\[\\]');
+    glob._replace('/[', '/' + (opts.dot ? dotfiles : nodot) + '[', true);
+    glob._replace('/?', '/' + (opts.dot ? dotfiles : nodot) + '[^/]', true);
+    glob._replace('/.', '/(?=.)\\.', true);
+
+    // windows drives
+    glob._replace(/^(\w):([\\\/]+?)/gi, '(?=.)$1:$2', true);
+
+    // negate slashes in exclusion ranges
+    if (glob.pattern.indexOf('[^') !== -1) {
+      glob.pattern = negateSlash(glob.pattern);
+    }
+
+    if (opts.globstar !== false && glob.pattern === '**') {
+      glob.pattern = globstar(opts.dot);
+
+    } else {
+      // '/*/*/*' => '(?:/*){3}'
+      glob._replace(/(\/\*)+/g, function(match) {
+        var len = match.length / 2;
+        if (len === 1) { return match; }
+        return '(?:\\/*){' + len + '}';
+      });
+
+      glob.pattern = balance(glob.pattern, '[', ']');
+      glob.escape(glob.pattern);
+
+      // if the pattern has `**`
+      if (tok.is.globstar) {
+        glob.pattern = collapse(glob.pattern, '/**');
+        glob.pattern = collapse(glob.pattern, '**/');
+        glob._replace('/**/', '(?:/' + globstar(opts.dot) + '/|/)', true);
+        glob._replace(/\*{2,}/g, '**');
+
+        // 'foo/*'
+        glob._replace(/(\w+)\*(?!\/)/g, '$1[^/]*?', true);
+        glob._replace(/\*\*\/\*(\w)/g, globstar(opts.dot) + '\\/' + (opts.dot ? dotfiles : nodot) + '[^/]*?$1', true);
+
+        if (opts.dot !== true) {
+          glob._replace(/\*\*\/(.)/g, '(?:**\\/|)$1');
+        }
+
+        // 'foo/**' or '{**,*}', but not 'foo**'
+        if (tok.path.dirname !== '' || /,\*\*|\*\*,/.test(glob.orig)) {
+          glob._replace('**', globstar(opts.dot), true);
+        }
+      }
+
+      // ends with /*
+      glob._replace(/\/\*$/, '\\/' + oneStar(opts.dot), true);
+      // ends with *, no slashes
+      glob._replace(/(?!\/)\*$/, star, true);
+      // has 'n*.' (partial wildcard w/ file extension)
+      glob._replace(/([^\/]+)\*/, '$1' + oneStar(true), true);
+      // has '*'
+      glob._replace('*', oneStar(opts.dot), true);
+      glob._replace('?.', '?\\.', true);
+      glob._replace('?:', '?:', true);
+
+      glob._replace(/\?+/g, function(match) {
+        var len = match.length;
+        if (len === 1) {
+          return qmark;
+        }
+        return qmark + '{' + len + '}';
+      });
+
+      // escape '.abc' => '\\.abc'
+      glob._replace(/\.([*\w]+)/g, '\\.$1');
+      // fix '[^\\\\/]'
+      glob._replace(/\[\^[\\\/]+\]/g, qmark);
+      // '///' => '\/'
+      glob._replace(/\/+/g, '\\/');
+      // '\\\\\\' => '\\'
+      glob._replace(/\\{2,}/g, '\\');
+    }
+
+    // unescape previously escaped patterns
+    glob.unescape(glob.pattern);
+    glob._replace('__UNESC_STAR__', '*');
+
+    // escape dots that follow qmarks
+    glob._replace('?.', '?\\.');
+
+    // remove unnecessary slashes in character classes
+    glob._replace('[^\\/]', qmark);
+
+    if (glob.pattern.length > 1) {
+      if (/^[\[?*]/.test(glob.pattern)) {
+        // only prepend the string if we don't want to match dotfiles
+        glob.pattern = (opts.dot ? dotfiles : nodot) + glob.pattern;
+      }
+    }
+
     return glob;
   }
 
-  glob.pattern = glob.pattern.replace(/(\+)(?!\()/g, '\\$1');
-  glob.pattern = glob.pattern.split('$').join('\\$');
+  /**
+   * Collapse repeated character sequences.
+   *
+   * ```js
+   * collapse('a/../../../b', '../');
+   * //=> 'a/../b'
+   * ```
+   *
+   * @param  {String} `str`
+   * @param  {String} `ch` Character sequence to collapse
+   * @return {String}
+   */
 
-  if (typeof opts.braces !== 'boolean' && typeof opts.nobraces !== 'boolean') {
-    opts.braces = true;
-  }
-
-  if (glob.pattern === '.*') {
-    return {
-      pattern: '\\.' + star,
-      tokens: tok,
-      options: opts
-    };
-  }
-
-  if (glob.pattern === '*') {
-    return {
-      pattern: oneStar(opts.dot),
-      tokens: tok,
-      options: opts
-    };
-  }
-
-  // parse the glob pattern into tokens
-  glob.parse();
-  var tok = glob.tokens;
-  tok.is.negated = opts.negated;
-
-  // dotfile handling
-  if ((opts.dotfiles === true || tok.is.dotfile) && opts.dot !== false) {
-    opts.dotfiles = true;
-    opts.dot = true;
-  }
-
-  if ((opts.dotdirs === true || tok.is.dotdir) && opts.dot !== false) {
-    opts.dotdirs = true;
-    opts.dot = true;
-  }
-
-  // check for braces with a dotfile pattern
-  if (/[{,]\./.test(glob.pattern)) {
-    opts.makeRe = false;
-    opts.dot = true;
-  }
-
-  if (opts.nonegate !== true) {
-    opts.negated = glob.negated;
-  }
-
-  // if the leading character is a dot or a slash, escape it
-  if (glob.pattern.charAt(0) === '.' && glob.pattern.charAt(1) !== '/') {
-    glob.pattern = '\\' + glob.pattern;
+  function collapse(str, ch) {
+    var res = str.split(ch);
+    var isFirst = res[0] === '';
+    var isLast = res[res.length - 1] === '';
+    res = res.filter(Boolean);
+    if (isFirst) res.unshift('');
+    if (isLast) res.push('');
+    return res.join(ch);
   }
 
   /**
-   * Extended globs
+   * Negate slashes in exclusion ranges, per glob spec:
+   *
+   * ```js
+   * negateSlash('[^foo]');
+   * //=> '[^\\/foo]'
+   * ```
+   *
+   * @param  {String} `str` glob pattern
+   * @return {String}
    */
 
-  // expand braces, e.g `{1..5}`
-  glob.track('before braces');
-  if (tok.is.braces) {
-    glob.braces();
-  }
-  glob.track('after braces');
-
-  // expand extglobs, e.g `foo/!(a|b)`
-  glob.track('before extglob');
-  if (tok.is.extglob) {
-    glob.extglob();
-  }
-  glob.track('after extglob');
-
-  // expand brackets, e.g `[[:alpha:]]`
-  glob.track('before brackets');
-  if (tok.is.brackets) {
-    glob.brackets();
-  }
-  glob.track('after brackets');
-
-  // special patterns
-  glob._replace('[!', '[^');
-  glob._replace('(?', '(%~');
-  glob._replace(/\[\]/, '\\[\\]');
-  glob._replace('/[', '/' + (opts.dot ? dotfiles : nodot) + '[', true);
-  glob._replace('/?', '/' + (opts.dot ? dotfiles : nodot) + '[^/]', true);
-  glob._replace('/.', '/(?=.)\\.', true);
-
-  // windows drives
-  glob._replace(/^(\w):([\\\/]+?)/gi, '(?=.)$1:$2', true);
-
-  // negate slashes in exclusion ranges
-  if (glob.pattern.indexOf('[^') !== -1) {
-    glob.pattern = negateSlash(glob.pattern);
-  }
-
-  if (opts.globstar !== false && glob.pattern === '**') {
-    glob.pattern = globstar(opts.dot);
-
-  } else {
-    // '/*/*/*' => '(?:/*){3}'
-    glob._replace(/(\/\*)+/g, function(match) {
-      var len = match.length / 2;
-      if (len === 1) { return match; }
-      return '(?:\\/*){' + len + '}';
+  function negateSlash(str) {
+    return str.replace(/\[\^([^\]]*?)\]/g, function(match, inner) {
+      if (inner.indexOf('/') === -1) {
+        inner = '\\/' + inner;
+      }
+      return '[^' + inner + ']';
     });
-
-    glob.pattern = balance(glob.pattern, '[', ']');
-    glob.escape(glob.pattern);
-
-    // if the pattern has `**`
-    if (tok.is.globstar) {
-      glob.pattern = collapse(glob.pattern, '/**');
-      glob.pattern = collapse(glob.pattern, '**/');
-      glob._replace('/**/', '(?:/' + globstar(opts.dot) + '/|/)', true);
-      glob._replace(/\*{2,}/g, '**');
-
-      // 'foo/*'
-      glob._replace(/(\w+)\*(?!\/)/g, '$1[^/]*?', true);
-      glob._replace(/\*\*\/\*(\w)/g, globstar(opts.dot) + '\\/' + (opts.dot ? dotfiles : nodot) + '[^/]*?$1', true);
-
-      if (opts.dot !== true) {
-        glob._replace(/\*\*\/(.)/g, '(?:**\\/|)$1');
-      }
-
-      // 'foo/**' or '{**,*}', but not 'foo**'
-      if (tok.path.dirname !== '' || /,\*\*|\*\*,/.test(glob.orig)) {
-        glob._replace('**', globstar(opts.dot), true);
-      }
-    }
-
-    // ends with /*
-    glob._replace(/\/\*$/, '\\/' + oneStar(opts.dot), true);
-    // ends with *, no slashes
-    glob._replace(/(?!\/)\*$/, star, true);
-    // has 'n*.' (partial wildcard w/ file extension)
-    glob._replace(/([^\/]+)\*/, '$1' + oneStar(true), true);
-    // has '*'
-    glob._replace('*', oneStar(opts.dot), true);
-    glob._replace('?.', '?\\.', true);
-    glob._replace('?:', '?:', true);
-
-    glob._replace(/\?+/g, function(match) {
-      var len = match.length;
-      if (len === 1) {
-        return qmark;
-      }
-      return qmark + '{' + len + '}';
-    });
-
-    // escape '.abc' => '\\.abc'
-    glob._replace(/\.([*\w]+)/g, '\\.$1');
-    // fix '[^\\\\/]'
-    glob._replace(/\[\^[\\\/]+\]/g, qmark);
-    // '///' => '\/'
-    glob._replace(/\/+/g, '\\/');
-    // '\\\\\\' => '\\'
-    glob._replace(/\\{2,}/g, '\\');
   }
 
-  // unescape previously escaped patterns
-  glob.unescape(glob.pattern);
-  glob._replace('__UNESC_STAR__', '*');
+  /**
+   * Escape imbalanced braces/bracket. This is a very
+   * basic, naive implementation that only does enough
+   * to serve the purpose.
+   */
 
-  // escape dots that follow qmarks
-  glob._replace('?.', '?\\.');
+  function balance(str, a, b) {
+    var aarr = str.split(a);
+    var alen = aarr.join('').length;
+    var blen = str.split(b).join('').length;
 
-  // remove unnecessary slashes in character classes
-  glob._replace('[^\\/]', qmark);
-
-  if (glob.pattern.length > 1) {
-    if (/^[\[?*]/.test(glob.pattern)) {
-      // only prepend the string if we don't want to match dotfiles
-      glob.pattern = (opts.dot ? dotfiles : nodot) + glob.pattern;
+    if (alen !== blen) {
+      str = aarr.join('\\' + a);
+      return str.split(b).join('\\' + b);
     }
+    return str;
   }
 
-  return glob;
-}
+  /**
+   * Special patterns to be converted to regex.
+   * Heuristics are used to simplify patterns
+   * and speed up processing.
+   */
 
-/**
- * Collapse repeated character sequences.
- *
- * ```js
- * collapse('a/../../../b', '../');
- * //=> 'a/../b'
- * ```
- *
- * @param  {String} `str`
- * @param  {String} `ch` Character sequence to collapse
- * @return {String}
- */
+  /* eslint no-multi-spaces: 0 */
+  var qmark       = '[^/]';
+  var star        = qmark + '*?';
+  var nodot       = '(?!\\.)(?=.)';
+  var dotfileGlob = '(?:\\/|^)\\.{1,2}($|\\/)';
+  var dotfiles    = '(?!' + dotfileGlob + ')(?=.)';
+  var twoStarDot  = '(?:(?!' + dotfileGlob + ').)*?';
 
-function collapse(str, ch) {
-  var res = str.split(ch);
-  var isFirst = res[0] === '';
-  var isLast = res[res.length - 1] === '';
-  res = res.filter(Boolean);
-  if (isFirst) res.unshift('');
-  if (isLast) res.push('');
-  return res.join(ch);
-}
+  /**
+   * Create a regex for `*`.
+   *
+   * If `dot` is true, or the pattern does not begin with
+   * a leading star, then return the simpler regex.
+   */
 
-/**
- * Negate slashes in exclusion ranges, per glob spec:
- *
- * ```js
- * negateSlash('[^foo]');
- * //=> '[^\\/foo]'
- * ```
- *
- * @param  {String} `str` glob pattern
- * @return {String}
- */
-
-function negateSlash(str) {
-  return str.replace(/\[\^([^\]]*?)\]/g, function(match, inner) {
-    if (inner.indexOf('/') === -1) {
-      inner = '\\/' + inner;
-    }
-    return '[^' + inner + ']';
-  });
-}
-
-/**
- * Escape imbalanced braces/bracket. This is a very
- * basic, naive implementation that only does enough
- * to serve the purpose.
- */
-
-function balance(str, a, b) {
-  var aarr = str.split(a);
-  var alen = aarr.join('').length;
-  var blen = str.split(b).join('').length;
-
-  if (alen !== blen) {
-    str = aarr.join('\\' + a);
-    return str.split(b).join('\\' + b);
+  function oneStar(dotfile) {
+    return dotfile ? '(?!' + dotfileGlob + ')(?=.)' + star : (nodot + star);
   }
-  return str;
-}
 
-/**
- * Special patterns to be converted to regex.
- * Heuristics are used to simplify patterns
- * and speed up processing.
- */
+  function globstar(dotfile) {
+    if (dotfile) { return twoStarDot; }
+    return '(?:(?!(?:\\/|^)\\.).)*?';
+  }
 
-/* eslint no-multi-spaces: 0 */
-var qmark       = '[^/]';
-var star        = qmark + '*?';
-var nodot       = '(?!\\.)(?=.)';
-var dotfileGlob = '(?:\\/|^)\\.{1,2}($|\\/)';
-var dotfiles    = '(?!' + dotfileGlob + ')(?=.)';
-var twoStarDot  = '(?:(?!' + dotfileGlob + ').)*?';
-
-/**
- * Create a regex for `*`.
- *
- * If `dot` is true, or the pattern does not begin with
- * a leading star, then return the simpler regex.
- */
-
-function oneStar(dotfile) {
-  return dotfile ? '(?!' + dotfileGlob + ')(?=.)' + star : (nodot + star);
-}
-
-function globstar(dotfile) {
-  if (dotfile) { return twoStarDot; }
-  return '(?:(?!(?:\\/|^)\\.).)*?';
-}
+  return expand;
+};

--- a/lib/glob.js
+++ b/lib/glob.js
@@ -7,187 +7,199 @@ var utils = require('./utils');
  * Expose `Glob`
  */
 
-var Glob = module.exports = function Glob(pattern, options) {
-  if (!(this instanceof Glob)) {
-    return new Glob(pattern, options);
-  }
-  this.options = options || {};
-  this.pattern = pattern;
-  this.history = [];
-  this.tokens = {};
-  this.init(pattern);
+module.exports = create(utils);
+
+module.exports.unlazy = function() {
+  var utils = require('./utils').unlazy();
+  return create(utils);
 };
 
-/**
- * Initialize defaults
- */
+function create(utils) {
 
-Glob.prototype.init = function(pattern) {
-  this.orig = pattern;
-  this.negated = this.isNegated();
-  this.options.track = this.options.track || false;
-  this.options.makeRe = true;
-};
-
-/**
- * Push a change into `glob.history`. Useful
- * for debugging.
- */
-
-Glob.prototype.track = function(msg) {
-  if (this.options.track) {
-    this.history.push({msg: msg, pattern: this.pattern});
-  }
-};
-
-/**
- * Return true if `glob.pattern` was negated
- * with `!`, also remove the `!` from the pattern.
- *
- * @return {Boolean}
- */
-
-Glob.prototype.isNegated = function() {
-  if (this.pattern.charCodeAt(0) === 33 /* '!' */) {
-    this.pattern = this.pattern.slice(1);
-    return true;
-  }
-  return false;
-};
-
-/**
- * Expand braces in the given glob pattern.
- *
- * We only need to use the [braces] lib when
- * patterns are nested.
- */
-
-Glob.prototype.braces = function() {
-  if (this.options.nobraces !== true && this.options.nobrace !== true) {
-    // naive/fast check for imbalanced characters
-    var a = this.pattern.match(/[\{\(\[]/g);
-    var b = this.pattern.match(/[\}\)\]]/g);
-
-    // if imbalanced, don't optimize the pattern
-    if (a && b && (a.length !== b.length)) {
-      this.options.makeRe = false;
+  function Glob(pattern, options) {
+    if (!(this instanceof Glob)) {
+      return new Glob(pattern, options);
     }
+    this.options = options || {};
+    this.pattern = pattern;
+    this.history = [];
+    this.tokens = {};
+    this.init(pattern);
+  };
 
-    // expand brace patterns and join the resulting array
-    var expanded = utils.braces(this.pattern, this.options);
-    this.pattern = expanded.join('|');
-  }
-};
+  /**
+   * Initialize defaults
+   */
 
-/**
- * Expand bracket expressions in `glob.pattern`
- */
+  Glob.prototype.init = function(pattern) {
+    this.orig = pattern;
+    this.negated = this.isNegated();
+    this.options.track = this.options.track || false;
+    this.options.makeRe = true;
+  };
 
-Glob.prototype.brackets = function() {
-  if (this.options.nobrackets !== true) {
-    this.pattern = utils.brackets(this.pattern);
-  }
-};
+  /**
+   * Push a change into `glob.history`. Useful
+   * for debugging.
+   */
 
-/**
- * Expand bracket expressions in `glob.pattern`
- */
-
-Glob.prototype.extglob = function() {
-  if (this.options.noextglob === true) return;
-
-  if (utils.isExtglob(this.pattern)) {
-    this.pattern = utils.extglob(this.pattern, {escape: true});
-  }
-};
-
-/**
- * Parse the given pattern
- */
-
-Glob.prototype.parse = function(pattern) {
-  this.tokens = utils.parseGlob(pattern || this.pattern, true);
-  return this.tokens;
-};
-
-/**
- * Replace `a` with `b`. Also tracks the change before and
- * after each replacement. This is disabled by default, but
- * can be enabled by setting `options.track` to true.
- *
- * Also, when the pattern is a string, `.split()` is used,
- * because it's much faster than replace.
- *
- * @param  {RegExp|String} `a`
- * @param  {String} `b`
- * @param  {Boolean} `escape` When `true`, escapes `*` and `?` in the replacement.
- * @return {String}
- */
-
-Glob.prototype._replace = function(a, b, escape) {
-  this.track('before (find): "' + a + '" (replace with): "' + b + '"');
-  if (escape) b = esc(b);
-  if (a && b && typeof a === 'string') {
-    this.pattern = this.pattern.split(a).join(b);
-  } else {
-    this.pattern = this.pattern.replace(a, b);
-  }
-  this.track('after');
-};
-
-/**
- * Escape special characters in the given string.
- *
- * @param  {String} `str` Glob pattern
- * @return {String}
- */
-
-Glob.prototype.escape = function(str) {
-  this.track('before escape: ');
-  var re = /["\\](['"]?[^"'\\]['"]?)/g;
-
-  this.pattern = str.replace(re, function($0, $1) {
-    var o = chars.ESC;
-    var ch = o && o[$1];
-    if (ch) {
-      return ch;
+  Glob.prototype.track = function(msg) {
+    if (this.options.track) {
+      this.history.push({msg: msg, pattern: this.pattern});
     }
-    if (/[a-z]/i.test($0)) {
-      return $0.split('\\').join('');
+  };
+
+  /**
+   * Return true if `glob.pattern` was negated
+   * with `!`, also remove the `!` from the pattern.
+   *
+   * @return {Boolean}
+   */
+
+  Glob.prototype.isNegated = function() {
+    if (this.pattern.charCodeAt(0) === 33 /* '!' */) {
+      this.pattern = this.pattern.slice(1);
+      return true;
     }
-    return $0;
-  });
+    return false;
+  };
 
-  this.track('after escape: ');
+  /**
+   * Expand braces in the given glob pattern.
+   *
+   * We only need to use the [braces] lib when
+   * patterns are nested.
+   */
+
+  Glob.prototype.braces = function() {
+    if (this.options.nobraces !== true && this.options.nobrace !== true) {
+      // naive/fast check for imbalanced characters
+      var a = this.pattern.match(/[\{\(\[]/g);
+      var b = this.pattern.match(/[\}\)\]]/g);
+
+      // if imbalanced, don't optimize the pattern
+      if (a && b && (a.length !== b.length)) {
+        this.options.makeRe = false;
+      }
+
+      // expand brace patterns and join the resulting array
+      var expanded = utils.braces(this.pattern, this.options);
+      this.pattern = expanded.join('|');
+    }
+  };
+
+  /**
+   * Expand bracket expressions in `glob.pattern`
+   */
+
+  Glob.prototype.brackets = function() {
+    if (this.options.nobrackets !== true) {
+      this.pattern = utils.brackets(this.pattern);
+    }
+  };
+
+  /**
+   * Expand bracket expressions in `glob.pattern`
+   */
+
+  Glob.prototype.extglob = function() {
+    if (this.options.noextglob === true) return;
+
+    if (utils.isExtglob(this.pattern)) {
+      this.pattern = utils.extglob(this.pattern, {escape: true});
+    }
+  };
+
+  /**
+   * Parse the given pattern
+   */
+
+  Glob.prototype.parse = function(pattern) {
+    this.tokens = utils.parseGlob(pattern || this.pattern, true);
+    return this.tokens;
+  };
+
+  /**
+   * Replace `a` with `b`. Also tracks the change before and
+   * after each replacement. This is disabled by default, but
+   * can be enabled by setting `options.track` to true.
+   *
+   * Also, when the pattern is a string, `.split()` is used,
+   * because it's much faster than replace.
+   *
+   * @param  {RegExp|String} `a`
+   * @param  {String} `b`
+   * @param  {Boolean} `escape` When `true`, escapes `*` and `?` in the replacement.
+   * @return {String}
+   */
+
+  Glob.prototype._replace = function(a, b, escape) {
+    this.track('before (find): "' + a + '" (replace with): "' + b + '"');
+    if (escape) b = esc(b);
+    if (a && b && typeof a === 'string') {
+      this.pattern = this.pattern.split(a).join(b);
+    } else {
+      this.pattern = this.pattern.replace(a, b);
+    }
+    this.track('after');
+  };
+
+  /**
+   * Escape special characters in the given string.
+   *
+   * @param  {String} `str` Glob pattern
+   * @return {String}
+   */
+
+  Glob.prototype.escape = function(str) {
+    this.track('before escape: ');
+    var re = /["\\](['"]?[^"'\\]['"]?)/g;
+
+    this.pattern = str.replace(re, function($0, $1) {
+      var o = chars.ESC;
+      var ch = o && o[$1];
+      if (ch) {
+        return ch;
+      }
+      if (/[a-z]/i.test($0)) {
+        return $0.split('\\').join('');
+      }
+      return $0;
+    });
+
+    this.track('after escape: ');
+  };
+
+  /**
+   * Unescape special characters in the given string.
+   *
+   * @param  {String} `str`
+   * @return {String}
+   */
+
+  Glob.prototype.unescape = function(str) {
+    var re = /__([A-Z]+)_([A-Z]+)__/g;
+    this.pattern = str.replace(re, function($0, $1) {
+      return chars[$1][$0];
+    });
+    this.pattern = unesc(this.pattern);
+  };
+
+  /**
+   * Escape/unescape utils
+   */
+
+  function esc(str) {
+    str = str.split('?').join('%~');
+    str = str.split('*').join('%%');
+    return str;
+  }
+
+  function unesc(str) {
+    str = str.split('%~').join('?');
+    str = str.split('%%').join('*');
+    return str;
+  }
+
+  return Glob;
 };
-
-/**
- * Unescape special characters in the given string.
- *
- * @param  {String} `str`
- * @return {String}
- */
-
-Glob.prototype.unescape = function(str) {
-  var re = /__([A-Z]+)_([A-Z]+)__/g;
-  this.pattern = str.replace(re, function($0, $1) {
-    return chars[$1][$0];
-  });
-  this.pattern = unesc(this.pattern);
-};
-
-/**
- * Escape/unescape utils
- */
-
-function esc(str) {
-  str = str.split('?').join('%~');
-  str = str.split('*').join('%%');
-  return str;
-}
-
-function unesc(str) {
-  str = str.split('%~').join('?');
-  str = str.split('%%').join('*');
-  return str;
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,157 +3,178 @@
 var win32 = process && process.platform === 'win32';
 var path = require('path');
 var fileRe = require('filename-regex');
-var utils = require('lazy-cache')(require);
 
-/**
- * Temporarily re-assign require to trick browserify
- * into recognizing lazy-cached deps.
- */
+function create(options) {
+  options = options || {};
 
-/* eslint-disable no-undef */
-var fn = require;
-require = utils;
+  var utils = require('lazy-cache')(require);
 
-/**
- * Lazily required module dependencies
- */
+  /**
+   * Temporarily re-assign require to trick browserify
+   * into recognizing lazy-cached deps.
+   */
 
-require('arr-diff', 'diff');
-require('array-unique', 'unique');
-require('braces');
-require('expand-brackets', 'brackets');
-require('extglob');
-require('is-extglob');
-require('is-glob', 'isGlob');
-require('kind-of', 'typeOf');
-require('normalize-path', 'normalize');
-require('object.omit', 'omit');
-require('parse-glob');
-require('regex-cache', 'cache');
+  /* eslint-disable no-undef */
+  var fn = require;
+  require = utils;
 
-/**
- * Restore `require`
- */
+  /**
+   * Lazily required module dependencies
+   */
 
-require = fn;
+  require('arr-diff', 'diff');
+  require('array-unique', 'unique');
+  require('braces');
+  require('expand-brackets', 'brackets');
+  require('extglob');
+  require('is-extglob');
+  require('is-glob', 'isGlob');
+  require('kind-of', 'typeOf');
+  require('normalize-path', 'normalize');
+  require('object.omit', 'omit');
+  require('parse-glob');
+  require('regex-cache', 'cache');
 
-/**
- * Get the filename of a filepath
- *
- * @param {String} `string`
- * @return {String}
- */
+  /**
+   * Restore `require`
+   */
 
-utils.filename = function filename(fp) {
-  var seg = fp.match(fileRe());
-  return seg && seg[0];
-};
+  require = fn;
 
-/**
- * Returns a function that returns true if the given
- * pattern is the same as a given `filepath`
- *
- * @param {String} `pattern`
- * @return {Function}
- */
+  /**
+   * Get the filename of a filepath
+   *
+   * @param {String} `string`
+   * @return {String}
+   */
 
-utils.isPath = function isPath(pattern, opts) {
-  return function(fp) {
-    return pattern === utils.unixify(fp, opts);
+  utils.filename = function filename(fp) {
+    var seg = fp.match(fileRe());
+    return seg && seg[0];
   };
-};
 
-/**
- * Returns a function that returns true if the given
- * pattern contains a `filepath`
- *
- * @param {String} `pattern`
- * @return {Function}
- */
+  /**
+   * Returns a function that returns true if the given
+   * pattern is the same as a given `filepath`
+   *
+   * @param {String} `pattern`
+   * @return {Function}
+   */
 
-utils.hasPath = function hasPath(pattern, opts) {
-  return function(fp) {
-    return utils.unixify(pattern, opts).indexOf(fp) !== -1;
+  utils.isPath = function isPath(pattern, opts) {
+    return function(fp) {
+      return pattern === utils.unixify(fp, opts);
+    };
   };
-};
 
-/**
- * Returns a function that returns true if the given
- * pattern matches or contains a `filepath`
- *
- * @param {String} `pattern`
- * @return {Function}
- */
+  /**
+   * Returns a function that returns true if the given
+   * pattern contains a `filepath`
+   *
+   * @param {String} `pattern`
+   * @return {Function}
+   */
 
-utils.matchPath = function matchPath(pattern, opts) {
-  var fn = (opts && opts.contains)
-    ? utils.hasPath(pattern, opts)
-    : utils.isPath(pattern, opts);
-  return fn;
-};
-
-/**
- * Returns a function that returns true if the given
- * regex matches the `filename` of a file path.
- *
- * @param {RegExp} `re`
- * @return {Boolean}
- */
-
-utils.hasFilename = function hasFilename(re) {
-  return function(fp) {
-    var name = utils.filename(fp);
-    return name && re.test(name);
+  utils.hasPath = function hasPath(pattern, opts) {
+    return function(fp) {
+      return utils.unixify(pattern, opts).indexOf(fp) !== -1;
+    };
   };
-};
 
-/**
- * Coerce `val` to an array
- *
- * @param  {*} val
- * @return {Array}
- */
+  /**
+   * Returns a function that returns true if the given
+   * pattern matches or contains a `filepath`
+   *
+   * @param {String} `pattern`
+   * @return {Function}
+   */
 
-utils.arrayify = function arrayify(val) {
-  return !Array.isArray(val)
-    ? [val]
-    : val;
-};
+  utils.matchPath = function matchPath(pattern, opts) {
+    var fn = (opts && opts.contains)
+      ? utils.hasPath(pattern, opts)
+      : utils.isPath(pattern, opts);
+    return fn;
+  };
 
-/**
- * Normalize all slashes in a file path or glob pattern to
- * forward slashes.
- */
+  /**
+   * Returns a function that returns true if the given
+   * regex matches the `filename` of a file path.
+   *
+   * @param {RegExp} `re`
+   * @return {Boolean}
+   */
 
-utils.unixify = function unixify(fp, opts) {
-  if (opts && opts.unixify === false) return fp;
-  if (opts && opts.unixify === true || win32 || path.sep === '\\') {
-    return utils.normalize(fp, false);
-  }
-  if (opts && opts.unescape === true) {
-    return fp ? fp.toString().replace(/\\(\w)/g, '$1') : '';
-  }
-  return fp;
-};
+  utils.hasFilename = function hasFilename(re) {
+    return function(fp) {
+      var name = utils.filename(fp);
+      return name && re.test(name);
+    };
+  };
 
-/**
- * Escape/unescape utils
- */
+  /**
+   * Coerce `val` to an array
+   *
+   * @param  {*} val
+   * @return {Array}
+   */
 
-utils.escapePath = function escapePath(fp) {
-  return fp.replace(/[\\.]/g, '\\$&');
-};
+  utils.arrayify = function arrayify(val) {
+    return !Array.isArray(val)
+      ? [val]
+      : val;
+  };
 
-utils.unescapeGlob = function unescapeGlob(fp) {
-  return fp.replace(/[\\"']/g, '');
-};
+  /**
+   * Normalize all slashes in a file path or glob pattern to
+   * forward slashes.
+   */
 
-utils.escapeRe = function escapeRe(str) {
-  return str.replace(/[-[\\$*+?.#^\s{}(|)\]]/g, '\\$&');
-};
+  utils.unixify = function unixify(fp, opts) {
+    if (opts && opts.unixify === false) return fp;
+    if (opts && opts.unixify === true || win32 || path.sep === '\\') {
+      return utils.normalize(fp, false);
+    }
+    if (opts && opts.unescape === true) {
+      return fp ? fp.toString().replace(/\\(\w)/g, '$1') : '';
+    }
+    return fp;
+  };
+
+  /**
+   * Escape/unescape utils
+   */
+
+  utils.escapePath = function escapePath(fp) {
+    return fp.replace(/[\\.]/g, '\\$&');
+  };
+
+  utils.unescapeGlob = function unescapeGlob(fp) {
+    return fp.replace(/[\\"']/g, '');
+  };
+
+  utils.escapeRe = function escapeRe(str) {
+    return str.replace(/[-[\\$*+?.#^\s{}(|)\]]/g, '\\$&');
+  };
+
+  return utils;
+}
 
 /**
  * Expose `utils`
  */
 
-module.exports = utils;
+module.exports = create();
+
+/**
+ * Expose `unlazy` to allow loading dependencies immediately.
+ *
+ * ```js
+ * var utils = require('./lib/utils').unlazy();
+ * ```
+ *
+ * @return {Object} required utils
+ */
+
+module.exports.unlazy = function() {
+  return create({unlazy: true});
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "is-extglob": "^1.0.0",
     "is-glob": "^2.0.1",
     "kind-of": "^3.0.2",
-    "lazy-cache": "^1.0.0",
+    "lazy-cache": "^1.0.1",
     "normalize-path": "^2.0.1",
     "object.omit": "^2.0.0",
     "parse-glob": "^3.0.4",

--- a/test/glob.unlazy.js
+++ b/test/glob.unlazy.js
@@ -1,0 +1,120 @@
+'use strict';
+
+var assert = require('assert');
+var Glob = require('../lib/glob').unlazy();
+var mm = require('..');
+
+describe('Glob class', function() {
+  describe('constructor', function() {
+    it('should return an instance of Glob', function() {
+      var glob = new Glob('foo');
+      assert(glob instanceof Glob);
+    });
+
+    it('should instantiate without new', function() {
+      var glob = Glob('foo');
+      assert(glob instanceof Glob);
+    });
+  });
+
+  describe('instance', function() {
+    it('should expose `orig`', function() {
+      var glob = new Glob('!foo');
+      assert.equal(glob.orig, '!foo');
+    });
+
+    it('should expose `pattern`', function() {
+      var glob = new Glob('!foo');
+      assert.equal(glob.pattern, 'foo');
+    });
+
+    it('should expose `options`', function() {
+      var glob = new Glob('!foo');
+      assert(glob.options);
+      assert(typeof glob.options === 'object');
+    });
+  });
+
+  describe('tokens', function() {
+    it('should parse a glob pattern and expose a tokens object', function() {
+      var glob = new Glob('!foo');
+      glob.parse();
+      assert(glob.hasOwnProperty('tokens'));
+      assert(glob.tokens.hasOwnProperty('is'));
+    });
+
+    it('should recognize extglob patterns', function() {
+      var glob = new Glob('@(a|b)');
+      glob.parse();
+      assert(glob.tokens.is.extglob === true);
+    });
+  });
+
+  describe('.extglob()', function() {
+    it('should parse extglob patterns', function() {
+      var glob = new Glob('@(a|b)');
+      glob.parse();
+      glob.extglob();
+      assert.equal(glob.pattern, '(?:a|b)');
+    });
+
+    it('should ignore non-extglobs', function() {
+      var glob = new Glob('foo/*.js');
+      glob.parse();
+      glob.extglob();
+      assert.equal(glob.pattern, 'foo/*.js');
+    });
+
+    it('should parse extglob patterns', function() {
+      var glob = new Glob('@(a|b)', {noextglob: true});
+      glob.parse();
+      glob.extglob();
+      assert.equal(glob.pattern, '@(a|b)');
+    });
+  });
+
+  describe('patterns', function() {
+    it('should escape dots', function() {
+      var actual = mm.expand('.');
+      assert.deepEqual(actual.pattern, '\\.');
+    });
+
+    it('should strip leading !', function() {
+      var glob = new Glob('!foo');
+      assert.deepEqual(glob.pattern, 'foo');
+    });
+  });
+
+  describe('options', function() {
+    describe('options.track', function() {
+      it('should track history for debugging:', function() {
+        var actual = mm.expand('**/*.js', {track: true});
+        assert(actual.hasOwnProperty('history'));
+        assert(Array.isArray(actual.history));
+        assert(actual.history.length > 1);
+      });
+    });
+
+    describe('options.nonegate', function() {
+      it('should ignore negation patterns when `nonegate` is true:', function() {
+        var array = ['a.js', 'b.js', 'c.js'];
+        var actual = mm(array, '!*.js', {nonegate: true});
+        assert.deepEqual(array, actual);
+      });
+    });
+  });
+
+  describe('leading slash', function() {
+    it('should match paths with leading slashes:', function() {
+      var array = ['/a.js', '/b.js', '/c.js'];
+      var actual = mm(array, '/*.js');
+      assert.deepEqual(array, actual);
+    });
+
+    it('should match dotfiles with leading slashes:', function() {
+      var array = ['/.a.js', '/.b.js', '/.c.js'];
+      var actual = mm(array, '/.*.js');
+      assert.deepEqual(array, actual);
+    });
+  });
+});

--- a/test/micromatch.unlazy.js
+++ b/test/micromatch.unlazy.js
@@ -1,0 +1,234 @@
+/*!
+ * micromatch <https://github.com/jonschlinkert/micromatch>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+'use strict';
+
+var path = require('path');
+require('should');
+var argv = require('minimist')(process.argv.slice(2));
+var mm = require('..').unlazy();
+
+if ('multimatch' in argv) {
+  mm = require('multimatch');
+}
+
+describe('micromatch', function() {
+  it('should return an empty array when no pattern is passed:', function() {
+    mm(['.md']).should.eql([]);
+  });
+});
+
+describe('micromatch array patterns', function() {
+  it('should match file extensions:', function() {
+    mm(['.md'], ['.md']).should.eql(['.md']);
+    mm(['.txt'], ['.md']).should.eql([]);
+    mm(['.gitignore'], ['.md']).should.eql([]);
+  });
+
+  it('should match files with the given extension:', function() {
+    mm(['a.md', 'a.txt'], ['*.md']).should.eql(['a.md']);
+    mm(['.d.md'], ['.*.md']).should.eql(['.d.md']);
+    mm(['d.md'], ['*.md']).should.eql(['d.md']);
+    mm(['a/b/c/d.md'], ['*.md']).should.eql([]);
+  });
+  it('should not match dotfiles by default:', function() {
+    mm(['.gitignore'], ['*.md']).should.eql([]);
+    mm(['.verb.txt'], ['*.md']).should.eql([]);
+  });
+
+  describe('file paths:', function() {
+    it('should match full file paths using an array of patterns:', function() {
+      mm(['a/b/c.md', 'a/b/c.txt'], '!**/*.txt').should.eql(['a/b/c.md']);
+      mm(['.gitignore'], ['a/b/c/*.md']).should.eql([]);
+      mm(['.gitignore.md'], ['a/b/c/*.md']).should.eql([]);
+      mm(['a.js'], ['*.js']).should.eql(['a.js']);
+      mm(['a.js', 'b.js', 'a/b.js'], ['**/*.js']).should.eql(['a.js', 'b.js', 'a/b.js']);
+      mm(['a/b/c/d.gitignore.md'], ['a/b/c/*.md']).should.eql(['a/b/c/d.gitignore.md']);
+      mm(['a/b/d/.gitignore'], ['a/b/c/*.md']).should.eql([]);
+      mm(['a/b/c/xyz.md'], ['a/*/c/*.md']).should.eql(['a/b/c/xyz.md']);
+      mm(['a/b/c/xyz.md'], ['a/**/*.md']).should.eql(['a/b/c/xyz.md']);
+      mm(['a/b/c/d/e/f/xyz.md'], ['a/**/*.md']).should.eql(['a/b/c/d/e/f/xyz.md']);
+      mm(['a/b/c/.xyz.md'], ['a/b/c/.*.md']).should.eql(['a/b/c/.xyz.md']);
+      mm(['a/bb/c/xyz.md'], ['a/*/c/*.md']).should.eql(['a/bb/c/xyz.md']);
+      mm(['a/bbbb/c/xyz.md'], ['a/*/c/*.md']).should.eql(['a/bbbb/c/xyz.md']);
+      mm(['a/bb.bb/c/xyz.md'], ['a/*/c/*.md']).should.eql(['a/bb.bb/c/xyz.md']);
+      mm(['a/bb.bb/aa/bb/aa/c/xyz.md'], ['a/**/c/*.md']).should.eql(['a/bb.bb/aa/bb/aa/c/xyz.md']);
+      mm(['a/bb.bb/aa/b.b/aa/c/xyz.md'], ['a/**/c/*.md']).should.eql(['a/bb.bb/aa/b.b/aa/c/xyz.md']);
+    });
+
+    it('matchBase / negation:', function() {
+      mm(['a/b/c.md', 'a/b/c.txt'], ['*', '!*.md'], {matchBase: true}).should.eql(['a/b/c.txt']);
+    });
+  });
+
+
+  describe('special characters:', function() {
+    it('should match one character per question mark:', function() {
+      mm(['a/b/c.md'], ['a/?/c.md']).should.eql(['a/b/c.md']);
+      mm(['a/bb/c.md'], ['a/?/c.md']).should.eql([]);
+      mm(['a/bb/c.md'], ['a/??/c.md']).should.eql(['a/bb/c.md']);
+      mm(['a/bbb/c.md'], ['a/??/c.md']).should.eql([]);
+      mm(['a/bbb/c.md'], ['a/???/c.md']).should.eql(['a/bbb/c.md']);
+      mm(['a/bbbb/c.md'], ['a/????/c.md']).should.eql(['a/bbbb/c.md']);
+    });
+
+    it('should match multiple groups of question marks:', function() {
+      mm(['a/bb/c/dd/e.md'], ['a/?/c/?/e.md']).should.eql([]);
+      mm(['a/b/c/d/e.md'], ['a/?/c/?/e.md']).should.eql(['a/b/c/d/e.md']);
+      mm(['a/b/c/d/e.md'], ['a/?/c/???/e.md']).should.eql([]);
+      mm(['a/b/c/zzz/e.md'], ['a/?/c/???/e.md']).should.eql(['a/b/c/zzz/e.md']);
+    });
+
+    it('should use special characters and glob stars together:', function() {
+      mm(['a/b/c/d/e.md'], ['a/?/c/?/*/e.md']).should.eql([]);
+      mm(['a/b/c/d/e/e.md'], ['a/?/c/?/*/e.md']).should.eql(['a/b/c/d/e/e.md']);
+      mm(['a/b/c/d/efghijk/e.md'], ['a/?/c/?/*/e.md']).should.eql(['a/b/c/d/efghijk/e.md']);
+      mm(['a/b/c/d/efghijk/e.md'], ['a/?/**/e.md']).should.eql(['a/b/c/d/efghijk/e.md']);
+      mm(['a/bb/c/d/efghijk/e.md'], ['a/?/**/e.md']).should.eql([]);
+      mm(['a/b/c/d/efghijk/e.md'], ['a/*/?/**/e.md']).should.eql(['a/b/c/d/efghijk/e.md']);
+      mm(['a/b/c/d/efgh.ijk/e.md'], ['a/*/?/**/e.md']).should.eql(['a/b/c/d/efgh.ijk/e.md']);
+      mm(['a/b.bb/c/d/efgh.ijk/e.md'], ['a/*/?/**/e.md']).should.eql(['a/b.bb/c/d/efgh.ijk/e.md']);
+      mm(['a/bbb/c/d/efgh.ijk/e.md'], ['a/*/?/**/e.md']).should.eql(['a/bbb/c/d/efgh.ijk/e.md']);
+    });
+  });
+
+  describe('brace expansion:', function() {
+    it('should expand braces:', function() {
+      mm(['iii.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/d/iii.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/c/iii.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/cd/iii.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/cd/iii.md']);
+      mm(['a/b/ce/iii.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/ce/iii.md']);
+
+      mm(['xyz.md'], ['a/b/c{d,e}/xyz.md']).should.eql([]);
+      mm(['a/b/d/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/c/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/cd/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/cd/xyz.md']);
+      mm(['a/b/ce/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/ce/xyz.md']);
+    });
+  });
+
+  describe('double stars:', function() {
+    it('should match path segments:', function() {
+      mm(['.gitignore'], ['a/**/z/*.md']).should.eql([]);
+      mm(['a/b/z/.gitignore'], ['a/**/z/*.md']).should.eql([]);
+      mm(['a/b/c/d/e/z/d.md'], ['a/**/z/*.md']).should.eql(['a/b/c/d/e/z/d.md']);
+
+      mm(['a/b/c/d/e/z/d.md'], ['a/**/j/**/z/*.md']).should.eql([]);
+      mm(['a/b/c/j/e/z/d.md'], ['a/**/j/**/z/*.md']).should.eql(['a/b/c/j/e/z/d.md']);
+      mm(['a/b/c/d/e/j/n/p/o/z/d.md'], ['a/**/j/**/z/*.md']).should.eql(['a/b/c/d/e/j/n/p/o/z/d.md']);
+      mm(['a/b/c/j/e/z/d.txt'], ['a/**/j/**/z/*.md']).should.eql([]);
+
+      mm(['a/b/d/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql([]);
+      mm(['a/b/c/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql([]);
+      mm(['a/b/c/xyz.md'], ['a/b/**/c{d,e}/**/*.md'])
+      mm(['a/b/c/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md'])
+      mm(['a/b/c/xyz.md'], ['a/b/**/c{d,e}/**/.*.md'])
+      mm(['a/b/d/cd/e/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql(['a/b/d/cd/e/xyz.md']);
+      mm(['a/b/baz/ce/fez/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql(['a/b/baz/ce/fez/xyz.md']);
+    });
+  });
+
+  describe('negation', function() {
+    it('should create a regular expression for negating extensions:', function() {
+      mm(['.md'], ['!.md']).should.eql([]);
+      mm(['d.md'], ['!.md']).should.eql([]);
+      mm(['d.md'], ['*', '!.md']).should.eql(['d.md']);
+      mm(['d.md', 'c.txt'], ['*', '!.md']).should.eql(['d.md', 'c.txt']);
+      mm(['d.md', 'c.txt'], ['*', '!*.md']).should.eql(['c.txt']);
+    });
+
+    it('should negate files:', function() {
+      mm(['abc.md'], ['!*.md']).should.eql([]);
+      mm(['abc.md'], ['!**/*.md']).should.eql([]);
+      mm(['abc.txt'], ['*', '!*.md']).should.eql(['abc.txt']);
+      mm(['.dotfile.md'], ['!*.md']).should.eql([]);
+      mm(['.dotfile.txt'], ['.*', '!*.md']).should.eql(['.dotfile.txt']);
+    });
+
+    it('should match on full paths:', function() {
+      mm(['.gitignore'], ['a/b/c/*.md']).should.eql([]);
+      mm(['a/b/c/.gitignore'], ['a/b/c/*.md']).should.eql([]);
+      mm(['a/b/c/d.md'], ['a/b/c/*.md']).should.eql(['a/b/c/d.md']);
+      mm(['a/b/c/e.md'], ['a/b/c/*.md']).should.eql(['a/b/c/e.md']);
+    });
+
+    it('should expand braces:', function() {
+      mm(['iii.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/d/iii.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/c/iii.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/cd/iii.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/cd/iii.md']);
+      mm(['a/b/ce/iii.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/ce/iii.md']);
+
+      mm(['xyz.md'], ['a/b/c{d,e}/xyz.md']).should.eql([]);
+      mm(['a/b/d/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/c/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql([]);
+      mm(['a/b/cd/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/cd/xyz.md']);
+      mm(['a/b/ce/xyz.md'], ['a/b/c{d,e}/*.md']).should.eql(['a/b/ce/xyz.md']);
+      mm(['a/b/cef/xyz.md'], ['a/b/c{d,e{f,g}}/*.md']).should.eql(['a/b/cef/xyz.md']);
+      mm(['a/b/ceg/xyz.md'], ['a/b/c{d,e{f,g}}/*.md']).should.eql(['a/b/ceg/xyz.md']);
+      mm(['a/b/cd/xyz.md'], ['a/b/c{d,e{f,g}}/*.md']).should.eql(['a/b/cd/xyz.md']);
+    });
+
+    it('should create a regular expression for double stars:', function() {
+      mm(['.gitignore'], ['a/**/z/*.md']).should.eql([]);
+
+      mm(['a/b/z/.dotfile.md'], ['a/**/z/.*.md']).should.eql(['a/b/z/.dotfile.md']);
+      mm(['a/b/z/.dotfile'], ['a/**/z/*.md']).should.eql([]);
+      mm(['a/b/c/d/e/z/d.md'], ['a/**/z/*.md']).should.eql(['a/b/c/d/e/z/d.md']);
+
+      mm(['a/b/c/d/e/z/d.md'], ['a/**/j/**/z/*.md']).should.eql([]);
+      mm(['a/b/c/j/e/z/d.md'], ['a/**/j/**/z/*.md']).should.eql(['a/b/c/j/e/z/d.md']);
+      mm(['a/b/c/d/e/j/n/p/o/z/d.md'], ['a/**/j/**/z/*.md']).should.eql(['a/b/c/d/e/j/n/p/o/z/d.md']);
+      mm(['a/b/c/j/e/z/d.txt'], ['a/**/j/**/z/*.md']).should.eql([]);
+
+      mm(['a/b/d/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql([]);
+      mm(['a/b/c/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql([]);
+      mm(['a/b/d/cd/e/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql(['a/b/d/cd/e/xyz.md']);
+      mm(['a/b/baz/ce/fez/xyz.md'], ['a/b/**/c{d,e}/**/xyz.md']).should.eql(['a/b/baz/ce/fez/xyz.md']);
+    });
+  });
+
+
+  describe('options', function() {
+    it('should support the `matchBase` option:', function() {
+      mm(['a/b/c.md'], ['*.md']).should.eql([]);
+      mm(['a/b/c.md'], ['*.md'], {matchBase: true}).should.eql(['a/b/c.md']);
+      mm(['a/b.md', 'a/b.txt'], ['*.txt'], {matchBase: true}).should.eql(['a/b.txt']);
+    });
+
+    it('should support the `nocase` option:', function() {
+      mm(['a/b/d/e.md'], ['a/b/c/*.md']).should.eql([]);
+      mm(['a/b/c/e.md'], ['A/b/C/*.md']).should.eql([]);
+      mm(['a/b/c/e.md'], ['A/b/C/*.md'], {nocase: true}).should.eql(['a/b/c/e.md']);
+      mm(['a/b/c/e.md'], ['A/b/C/*.MD'], {nocase: true}).should.eql(['a/b/c/e.md']);
+      mm(['a/b/c.d/e.md'], ['A/b/C.d/*.MD'], {nocase: true}).should.eql(['a/b/c.d/e.md']);
+    });
+
+    it('should match dotfiles when `dotfile` is true:', function() {
+      var opts = { dot: true };
+
+      mm(['.gitignore'], ['.gitignore'], opts).should.eql(['.gitignore']);
+      mm(['d.md'], ['*.md'], opts).should.eql(['d.md']);
+      mm(['.verb.txt'], ['*.md'], opts).should.eql([]);
+      mm(['a/b/c/.gitignore'], ['*.md'], opts).should.eql([]);
+      mm(['a/b/c/.gitignore.md'], ['*.md'], opts).should.eql([]);
+      mm(['a/b/c/.gitignore.md'], ['**/*.md'], opts).should.eql(['a/b/c/.gitignore.md']);
+      mm(['.verb.txt'], ['*.md'], opts).should.eql([]);
+      mm(['.gitignore'], ['*.md'], opts).should.eql([]);
+      mm(['.gitignore'], ['*.*'], opts).should.eql(['.gitignore']);
+      mm(['.gitignore.md'], ['.*.md'], opts).should.eql(['.gitignore.md']);
+      mm(['.gitignore.md'], ['*.md'], opts).should.eql(['.gitignore.md']);
+      mm(['a/b/c/.verb.md'], ['**/*.md'], opts).should.eql(['a/b/c/.verb.md']);
+
+      mm(['a/b/c/.gitignore.md'], ['*.md']).should.eql([]);
+      mm(['a/b/c/.gitignore.md'], ['**/.*.md']).should.eql(['a/b/c/.gitignore.md']);
+      mm(['a/b/c/.gitignore.md'], ['**/.*']).should.eql(['a/b/c/.gitignore.md']);
+    });
+  });
+});
+

--- a/test/utils.unlazy.js
+++ b/test/utils.unlazy.js
@@ -1,0 +1,73 @@
+'use strict';
+
+require('should');
+var path = require('path');
+var assert = require('assert');
+var utils = require('../lib/utils').unlazy();
+var mm = require('..');
+
+describe('utils.hasPath', function() {
+  it('should return a function', function() {
+    assert.equal(typeof utils.hasPath('foo/bar'), 'function');
+  });
+
+  it('should return true if the first path contains the second:', function() {
+    assert.equal(utils.hasPath('foo/bar')('foo'), true);
+  });
+});
+
+describe('utils.matchPath', function() {
+  it('should return true if two paths are the same:', function() {
+    assert.equal(utils.matchPath('foo')('foo'), true);
+  });
+
+  it('should return true if the first path contains the second:', function() {
+    assert.equal(utils.matchPath('foo/bar', {contains: true})('foo'), true);
+  });
+});
+
+describe('utils.unixify', function() {
+  it('should convert a path to unix slashes', function() {
+    var sep = path.sep;
+    path.sep = '\\';
+    assert.equal(utils.unixify('foo\\bar'), 'foo/bar');
+    path.sep = sep;
+  });
+
+  it('should return an empty string:', function() {
+    assert.equal(utils.unixify(''), '');
+  });
+
+  it('should retain trailing slashes with unix paths:', function() {
+    assert.equal(utils.unixify('a/b/c/d/'), 'a/b/c/d/');
+  });
+
+  it('should retain trailing slashes with windows paths:', function() {
+    var sep = path.sep;
+    path.sep = '\\';
+    assert.equal(utils.unixify('a\\b\\c\\d\\'), 'a/b/c/d/');
+    path.sep = sep;
+  });
+
+  it('should unescape word chars when `options.unescape` is true:', function() {
+    var fp = utils.unixify('foo\\bar\\baz\\quux', {unescape: true});
+    assert.equal(fp, 'foobarbazquux');
+  });
+
+  it('should not blow up on empty strings:', function() {
+    var fp = utils.unixify('', {unescape: true});
+    assert.equal(fp, '');
+  });
+});
+
+describe('utils.escapePath', function() {
+  it('should escape dots and backslashes in a path', function() {
+    assert.equal(utils.escapePath('foo\\bar.baz'), 'foo\\\\bar\\.baz');
+  });
+});
+
+describe('utils.escapeRe', function() {
+  it('should escape regex characters in a path', function() {
+    assert.equal(utils.escapeRe('foo^bar*baz?#'), 'foo\\^bar\\*baz\\?\\#');
+  });
+});


### PR DESCRIPTION
Using updated `lazy-cache` and adding `.unlazy` method to main export to allow loading all dependencies immediately.

```js
var mm = require('micromatch').unlazy();
```

This will fix #52 in `nyc` when updated.